### PR TITLE
chore:[IWP-98] Add IssuerSigned decoding in JSON format

### DIFF
--- a/cbor/src/main/java/it/pagopa/io/wallet/cbor/parser/CBorParser.kt
+++ b/cbor/src/main/java/it/pagopa/io/wallet/cbor/parser/CBorParser.kt
@@ -36,6 +36,7 @@ class CBorParser private constructor(
     /**
      * It parses a document Cbor raw value to a json string
      * @param separateElementIdentifier false if you want to merge elementIdentifier and elementValue as i.e.:
+     * ```json
      * {
      *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
      *   "digestID": 14,
@@ -47,6 +48,7 @@ class CBorParser private constructor(
      *   "elementIdentifier": "family_name",
      *   "elementValue": "ANDERSSON"
      * }
+     * ```
      * @param onComplete callback with the json string
      * @param onError callback with the error as [Exception]*/
     fun documentsCborToJson(
@@ -65,9 +67,11 @@ class CBorParser private constructor(
             onComplete.invoke(model.toJson().toString())
         }, onError = onError ?: {})
     }
+
     /**
      * As [documentsCborToJson] It parses a issuerSigned Cbor raw value to a json string
      * @param separateElementIdentifier false if you want to merge elementIdentifier and elementValue as i.e.:
+     * ```json
      * {
      *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
      *   "digestID": 14,
@@ -79,6 +83,60 @@ class CBorParser private constructor(
      *   "elementIdentifier": "family_name",
      *   "elementValue": "ANDERSSON"
      * }
+     * ```
+     * The resulting JSON has the following general schema (keys may be omitted if their corresponding values are `null`):
+     *
+     * ```
+     * {
+     *   "issuerAuth": {
+     *     "rawValue": "<Base64Url-encoded string?>",
+     *     "protectedHeader": "<Base64Url-encoded string?>",
+     *     "unprotectedHeader": [
+     *       {
+     *         "algorithm": "<String?>",
+     *         "keyId": "<Base64Url-encoded string?>"
+     *       }
+     *     ],
+     *     "payload": {
+     *       "docType": "<String?>",
+     *       "version": "<String?>",
+     *       "validityInfo": { ... },             // JSONObject containing validity data
+     *       "digestAlgorithm": "<String?>",
+     *       "deviceKeyInfo": {
+     *         // JSON object representing device key info; may contain:
+     *         // {
+     *         //   "deviceKey": {
+     *         //     "kty": "EC",
+     *         //     "crv": "P-256"|"P-384"|"P-521",
+     *         //     "x": "<Base64Url-encoded string>",
+     *         //     "y": "<Base64Url-encoded string>"
+     *         //   }
+     *         // }
+     *       },
+     *       "valueDigests": {
+     *         "<docTypeKey?>": {
+     *           // A JSON object mapping integer keys to Base64-encoded strings
+     *         }
+     *       }
+     *     },
+     *     "signature": "<Base64Url-encoded string?>"
+     *   },
+     *   "nameSpaces": {
+     *     "<docTypeString>": [
+     *       {
+     *         "digestID": <Int?>,
+     *         "random": "<Base64Url-encoded string?>",
+     *         // If separateElementIdentifier = true:
+     *         "elementIdentifier": "<String?>",
+     *         "elementValue": (JSONObject | JSONArray | String?),
+     *         // Else (if false), the "elementIdentifier" becomes a nested key:
+     *         "<elementIdentifier>": (JSONObject | JSONArray | String?)
+     *       },
+     *       ...
+     *     ]
+     *   }
+     * }
+     * ```
      * @return json string or null if error*/
     @OptIn(ExperimentalEncodingApi::class)
     fun issuerSignedCborToJson(

--- a/cbor/src/main/java/it/pagopa/io/wallet/cbor/parser/CBorParser.kt
+++ b/cbor/src/main/java/it/pagopa/io/wallet/cbor/parser/CBorParser.kt
@@ -9,6 +9,8 @@ import org.json.JSONObject
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
+/**
+ * Class to parse cbor raw value to json string, it accepts both bytes[] value or Base64 string*/
 class CBorParser private constructor(
     private val source: Any,
     private val isByteArray: Boolean = false
@@ -16,6 +18,8 @@ class CBorParser private constructor(
     constructor(source: String) : this(source, false)
     constructor(source: ByteArray) : this(source, true)
 
+    /**
+     * It parses a Cbor raw value to a json string without any other intervention as [documentsCborToJson] or [issuerSignedCborToJson]*/
     @OptIn(ExperimentalEncodingApi::class)
     fun toJson(): String? {
         return try {
@@ -28,6 +32,23 @@ class CBorParser private constructor(
         }
     }
 
+
+    /**
+     * It parses a document Cbor raw value to a json string
+     * @param separateElementIdentifier false if you want to merge elementIdentifier and elementValue as i.e.:
+     * {
+     *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
+     *   "digestID": 14,
+     *   "family_name": "ANDERSSON"
+     * } else i.e.:
+     * {
+     *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
+     *   "digestID": 14,
+     *   "elementIdentifier": "family_name",
+     *   "elementValue": "ANDERSSON"
+     * }
+     * @param onComplete callback with the json string
+     * @param onError callback with the error as [Exception]*/
     fun documentsCborToJson(
         separateElementIdentifier: Boolean = true,
         onComplete: (String) -> Unit,
@@ -44,7 +65,21 @@ class CBorParser private constructor(
             onComplete.invoke(model.toJson().toString())
         }, onError = onError ?: {})
     }
-
+    /**
+     * As [documentsCborToJson] It parses a issuerSigned Cbor raw value to a json string
+     * @param separateElementIdentifier false if you want to merge elementIdentifier and elementValue as i.e.:
+     * {
+     *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
+     *   "digestID": 14,
+     *   "family_name": "ANDERSSON"
+     * } else i.e.:
+     * {
+     *   "random": "749knalJ0xgtGBK1lVhhXe8D-beFtIiXyln1UhmTPKmbNmTwvolOya3h-_AyFE2MqCom3sBYs8VylU238nkOTA==",
+     *   "digestID": 14,
+     *   "elementIdentifier": "family_name",
+     *   "elementValue": "ANDERSSON"
+     * }
+     * @return json string or null if error*/
     @OptIn(ExperimentalEncodingApi::class)
     fun issuerSignedCborToJson(
         separateElementIdentifier: Boolean = true

--- a/cbor/src/test/java/it/pagopa/io/wallet/cbor/CborParserTest.kt
+++ b/cbor/src/test/java/it/pagopa/io/wallet/cbor/CborParserTest.kt
@@ -2,6 +2,7 @@ package it.pagopa.io.wallet.cbor
 
 import com.upokecenter.cbor.CBORObject
 import it.pagopa.io.wallet.cbor.helper.toModelMDoc
+import it.pagopa.io.wallet.cbor.impl.MDoc
 import it.pagopa.io.wallet.cbor.parser.CBorParser
 import org.json.JSONObject
 import org.junit.Test
@@ -144,5 +145,28 @@ class CborParserTest {
             assert(json != null)
             println(json)
         })
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun `test issuer signed to JSON`() {
+        val rawCbor = kotlin.io.encoding.Base64.decode(moreDocsIssuerAuth)
+        MDoc(rawCbor).decodeMDoc(onComplete = {
+            it.documents?.forEachIndexed { i, document ->
+                document.issuerSigned?.rawValue?.let { issuerSigned ->
+                    val jsonString = CBorParser(issuerSigned).issuerSignedCborToJson()
+                    assert(jsonString != null)
+                    val json = JSONObject(jsonString!!)
+                    println("==================")
+                    println("ISSUER_SIGNED:")
+                    println(json)
+                    if (i == it.documents!!.size - 1)
+                        println("==================")
+                    assert(json.optJSONObject("nameSpaces") != null)
+                }
+            }
+        }) { ex ->
+            assert(ex != null)
+        }
     }
 }


### PR DESCRIPTION
## Add IssuerSigned decoding in JSON format

CBorParser(rawIssuerSigned).issuerSignedCborToJson now is exposed to who uses SDK.

method has  separateElementIdentifier: Boolean = true parameter.

rawIssuerSignedByteArray or Base64 string is passed to CBorParser constructor.

