### PR TITLE
feat: [IWP-102] added openId4vp flow  

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,16 @@ data class DocRequested(
 See in app MasterViewViewModel.shareInfo method to understand how to retrieve documents from JSON request and correctly
 send to response.
 
+##  ISO 18013-7
 
-
-
-
+class OpenID4VP can be used to generate a sessionTranscript to pass to ResponseGenerator to use standard ISO 18013-7.
+Class parameters can be retrieved by calling backend an getting parameters themselves.
+Example:
+```kotlin
+val sessionTranscript = OpenID4VP(
+   clientId,
+   responseUri,
+   authorizationRequestNonce,
+   mdocGeneratedNonce
+).createSessionTranscript()
+```

--- a/README.md
+++ b/README.md
@@ -274,3 +274,21 @@ val sessionTranscript = OpenID4VP(
    mdocGeneratedNonce
 ).createSessionTranscript()
 ```
+Then you can create a device response doing:
+```kotlin
+val responseGenerator = ResponseGenerator(sessionTranscript)
+responseGenerator.createResponse(
+    documents,
+    fieldRequestedAndAccepted,
+    object : ResponseGenerator.Response {
+        override fun onResponseGenerated(response: ByteArray) {
+            //do what you want with response
+        }
+
+        override fun onError(message: String) {
+            //ERROR!!
+        }
+    }
+)
+```
+

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/OpenID4VP.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/OpenID4VP.kt
@@ -1,0 +1,58 @@
+package it.pagopa.io.wallet.proximity
+
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.Simple
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+
+/** class to generate a DeviceResponse for ISO 18013-7 OID4VP flow.
+ * @param clientId Authorization Request 'client_id'
+ * @param responseUri: Authorization Request 'response_uri'
+ * @param authorizationRequestNonce: Authorization Request 'nonce'
+ * @param mdocGeneratedNonce: cryptographically random number with sufficient entropy
+ **/
+class OpenID4VP(
+    private val clientId: String,
+    private val responseUri: String,
+    private val authorizationRequestNonce: String,
+    private val mdocGeneratedNonce: String
+) {
+    /**Generate session transcript with OID4VPHandover
+     *@return A CBOR-encoded SessionTranscript object*/
+    fun createSessionTranscript(): ByteArray {
+        val clientIdToHash = Cbor.encode(
+            CborArray.builder()
+                .add(clientId)
+                .add(mdocGeneratedNonce)
+                .end()
+                .build()
+        )
+        val clientIdHash = Crypto.digest(Algorithm.SHA256, clientIdToHash)
+
+        val responseUriToHash = Cbor.encode(
+            CborArray.builder()
+                .add(responseUri)
+                .add(mdocGeneratedNonce)
+                .end()
+                .build()
+        )
+        val responseUriHash = Crypto.digest(Algorithm.SHA256, responseUriToHash)
+
+        val oid4vpHandover = CborArray.builder()
+            .add(clientIdHash)
+            .add(responseUriHash)
+            .add(authorizationRequestNonce)
+            .end()
+            .build()
+
+        return Cbor.encode(
+            CborArray.builder()
+                .add(Simple.NULL)
+                .add(Simple.NULL)
+                .add(oid4vpHandover)
+                .end()
+                .build()
+        )
+    }
+}

--- a/proximity/src/test/java/it/pagopa/io/wallet/proximity/ResponseGeneratorTest.kt
+++ b/proximity/src/test/java/it/pagopa/io/wallet/proximity/ResponseGeneratorTest.kt
@@ -1,6 +1,7 @@
 package it.pagopa.io.wallet.proximity
 
 import it.pagopa.io.wallet.cbor.model.DocType
+import it.pagopa.io.wallet.cbor.parser.CBorParser
 import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator.Response
@@ -16,6 +17,18 @@ class ResponseGeneratorTest {
     private val mockSessionsTranscript = ByteArray(10)
     private val mockFieldRequestedAndAccepted by lazy {
         JSONObject("""{"org.iso.18013.5.1.mDL":{"height":true,"weight":true,"portrait":true,"birth_date":true,"eye_colour":true,"given_name":true,"issue_date":true,"age_over_18":true,"age_over_21":true,"birth_place":true,"expiry_date":true,"family_name":true,"hair_colour":true,"nationality":true,"age_in_years":true,"resident_city":true,"age_birth_year":true,"resident_state":true,"document_number":true,"issuing_country":true,"resident_address":true,"resident_country":true,"issuing_authority":true,"driving_privileges":true,"issuing_jurisdiction":true,"resident_postal_code":true,"signature_usual_mark":true,"administrative_number":true,"portrait_capture_date":true,"un_distinguishing_sign":true,"given_name_national_character":true,"family_name_national_character":true}}""")
+    }
+
+    @Test
+    fun createOpenIdV4SessionTranscript(){
+        val sessionTranscript = OpenID4VP(
+            "clientId",
+            "responseUri",
+            "authorizationRequestNonce",
+            "mdocGeneratedNonce"
+        ).createSessionTranscript()
+        val parser= CBorParser(sessionTranscript).toJson()
+        println(parser)
     }
 
     @OptIn(ExperimentalEncodingApi::class)


### PR DESCRIPTION
## OpenIdVp4 Flow
Added a class called OpenID4VP which accepts as parameters:
1. clientId.
2. responseUri.
3. authorizationRequestNonce.
4. mdocGeneratedNonce.
 
It has a method called createSessionTranscript with no parameters which generates session transcript with OID4VPHandover
 
Example:
``` kotlin
val sessionTranscript = OpenID4VP(
   clientId,
   responseUri,
   authorizationRequestNonce,
   mdocGeneratedNonce
).createSessionTranscript()
```
this sessionTranscript can be passed to ResponseGenerator constructor.