### PR TITLE
fix: [WLEO-393] Restored kotlin version to 2.0.20

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,7 +72,7 @@ android {
 
 composeCompiler {
     reportsDestination = layout.buildDirectory.dir("compose_compiler")
-    stabilityConfigurationFiles.add(rootProject.layout.projectDirectory.file("stability_config.conf"))
+    stabilityConfigurationFile = rootProject.layout.projectDirectory.file("stability_config.conf")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.9.1"
 desugar_jdk_libs = "2.1.5"
 json = "20220924"
-kotlin = "2.1.20"
+kotlin = "2.0.20"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
## Short description

This PR restores the `Kotlin` version to `2.0.20` .

## List of changes proposed in this pull request

- `app/build.gradle.kts` , `gradle/libs.versions.toml`: restored `Kotlin` version to `2.0.20`.

## How to test

Check if the application compiles and all its features work.