### PR TITLE
feat: [IWP-122] aligned QrEngagementListener with IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,10 @@ The listener:
 
 ```kotlin
 interface QrEngagementListener {
-    fun onConnecting()
-    fun onDeviceRetrievalHelperReady(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
-    fun onCommunicationError(msg: String)
-    fun onNewDeviceRequest(request: String?, sessionsTranscript: ByteArray)
+    fun onDeviceConnecting()
+    fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
+    fun onError(msg: String)
+    fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray)
     fun onDeviceDisconnected(transportSpecificTermination: Boolean)
 }
 ```

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
@@ -230,11 +230,11 @@ class MasterViewViewModel(
 
     private fun attachListenerAndObserve() {
         qrCodeEngagement.withListener(object : QrEngagementListener {
-            override fun onConnecting() {
+            override fun onDeviceConnecting() {
                 this@MasterViewViewModel.loader.value = "Connecting"
             }
 
-            override fun onCommunicationError(msg: String) {
+            override fun onError(msg: String) {
                 ProximityLogger.e(
                     this@MasterViewViewModel.javaClass.name,
                     "onCommunicationError: $msg"
@@ -261,11 +261,11 @@ class MasterViewViewModel(
                 }
             }
 
-            override fun onDeviceRetrievalHelperReady(deviceRetrievalHelper: DeviceRetrievalHelperWrapper) {
+            override fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper) {
                 this@MasterViewViewModel.deviceConnected = deviceRetrievalHelper
             }
 
-            override fun onNewDeviceRequest(
+            override fun onDocumentRequestReceived(
                 request: String?,
                 sessionsTranscript: ByteArray
             ) {

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
@@ -234,10 +234,10 @@ class MasterViewViewModel(
                 this@MasterViewViewModel.loader.value = "Connecting"
             }
 
-            override fun onError(msg: String) {
+            override fun onError(error: Throwable) {
                 ProximityLogger.e(
                     this@MasterViewViewModel.javaClass.name,
-                    "onCommunicationError: $msg"
+                    "onCommunicationError: ${error.message}"
                 )
                 this@MasterViewViewModel.loader.value = null
             }

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/SlaveViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/SlaveViewViewModel.kt
@@ -31,8 +31,8 @@ class SlaveViewViewModel(
                 ProximityLogger.i("ProximityLogger", "onConnecting")
             }
 
-            override fun onError(msg: String) {
-                ProximityLogger.i("ProximityLogger", "onCommunicationError: $msg")
+            override fun onError(error: Throwable) {
+                ProximityLogger.i("ProximityLogger", "onCommunicationError: ${error.message}")
             }
 
             override fun onDeviceDisconnected(transportSpecificTermination: Boolean) {

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/SlaveViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/SlaveViewViewModel.kt
@@ -27,11 +27,11 @@ class SlaveViewViewModel(
 
     fun attachListenerAndObserve() {
         qrCodeEngagement.withListener(object : QrEngagementListener {
-            override fun onConnecting() {
+            override fun onDeviceConnecting() {
                 ProximityLogger.i("ProximityLogger", "onConnecting")
             }
 
-            override fun onCommunicationError(msg: String) {
+            override fun onError(msg: String) {
                 ProximityLogger.i("ProximityLogger", "onCommunicationError: $msg")
             }
 
@@ -40,12 +40,12 @@ class SlaveViewViewModel(
                 //this@SlaveViewViewModel.loader.value = null
             }
 
-            override fun onDeviceRetrievalHelperReady(deviceRetrievalHelper: DeviceRetrievalHelperWrapper) {
+            override fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper) {
                 ProximityLogger.i("ProximityLogger", "onDeviceRetrievalHelperReady")
                 this@SlaveViewViewModel.deviceConnected = deviceRetrievalHelper
             }
 
-            override fun onNewDeviceRequest(request: String?, sessionsTranscript: ByteArray) {
+            override fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray) {
                 ProximityLogger.i("request", request.orEmpty())
             }
         })

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
@@ -147,7 +147,7 @@ class QrEngagement private constructor(
 
         override fun onError(error: Throwable) {
             ProximityLogger.e(this.javaClass.name, "QR onError: ${error.message}")
-            listener?.onError("$error")
+            listener?.onError(error)
         }
     }
 
@@ -212,7 +212,7 @@ class QrEngagement private constructor(
                 this.javaClass.name,
                 "DeviceRetrievalHelper Listener (QR): onError -> ${error.message}"
             )
-            listener?.onError("$error")
+            listener?.onError(error)
         }
     }
 

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
@@ -109,7 +109,7 @@ class QrEngagement private constructor(
     private val qrEngagementListener = object : QrEngagementHelper.Listener {
         override fun onDeviceConnecting() {
             ProximityLogger.d(this.javaClass.name, "QR Engagement: Device Connecting")
-            listener?.onConnecting()
+            listener?.onDeviceConnecting()
         }
 
         override fun onDeviceConnected(transport: DataTransport) {
@@ -138,7 +138,7 @@ class QrEngagement private constructor(
             ).build()
             deviceRetrievalHelper = DeviceRetrievalHelperWrapper(deviceRetrievalHelperBuilt)
             qrEngagement.close()
-            listener?.onDeviceRetrievalHelperReady(
+            listener?.onDeviceConnected(
                 requireNotNull(
                     deviceRetrievalHelper
                 )
@@ -147,7 +147,7 @@ class QrEngagement private constructor(
 
         override fun onError(error: Throwable) {
             ProximityLogger.e(this.javaClass.name, "QR onError: ${error.message}")
-            listener?.onCommunicationError("$error")
+            listener?.onError("$error")
         }
     }
 
@@ -190,7 +190,7 @@ class QrEngagement private constructor(
             }
             val jsonToSend = requestWrapperList.toTypedArray().toRequest()
             ProximityLogger.i("REQ_JSON", jsonToSend.toString())
-            listener?.onNewDeviceRequest(
+            listener?.onDocumentRequestReceived(
                 if (jsonToSend.keys().asSequence().toMutableList().isEmpty())
                     null
                 else
@@ -212,7 +212,7 @@ class QrEngagement private constructor(
                 this.javaClass.name,
                 "DeviceRetrievalHelper Listener (QR): onError -> ${error.message}"
             )
-            listener?.onCommunicationError("$error")
+            listener?.onError("$error")
         }
     }
 
@@ -268,7 +268,7 @@ class QrEngagement private constructor(
             ba,
             engagement.originInfos
         ).build()
-        listener?.onDeviceRetrievalHelperReady(DeviceRetrievalHelperWrapper(deviceRetrievalHelper))
+        listener?.onDeviceConnected(DeviceRetrievalHelperWrapper(deviceRetrievalHelper))
     }
 
     /**

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
@@ -2,10 +2,27 @@ package it.pagopa.io.wallet.proximity.qr_code
 
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 
+/**
+ * Interface to listen all the events that can occur during the communication with the other device (mdocReader)
+ * */
 interface QrEngagementListener {
+    /**Device is connecting with mdocReader*/
     fun onDeviceConnecting()
+
+    /**Device is connected
+     * @param deviceRetrievalHelper a wrapper around DeviceRetrievalHelper from mdoc library to send a response and disconnect from mdocReader*/
     fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
+
+    /**Some error happened
+     * @param error Exception reached*/
     fun onError(error: Throwable)
+
+    /**A request was received, we can handle it using deviceRetrievalHelper obj from [onDeviceConnected]
+     * @param request a JSONObject representing a doc request from mdocReader
+     * @param sessionsTranscript a ByteArray representing the transcript of the session between mdocReader and the device*/
     fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray)
+
+    /**The other device is disconnected
+     * @param transportSpecificTermination true if is all ok and the other device has received all the data, false otherwise*/
     fun onDeviceDisconnected(transportSpecificTermination: Boolean)
 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
@@ -5,7 +5,7 @@ import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 interface QrEngagementListener {
     fun onDeviceConnecting()
     fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
-    fun onError(msg: String)
+    fun onError(error: Throwable)
     fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray)
     fun onDeviceDisconnected(transportSpecificTermination: Boolean)
 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagementListener.kt
@@ -3,9 +3,9 @@ package it.pagopa.io.wallet.proximity.qr_code
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 
 interface QrEngagementListener {
-    fun onConnecting()
-    fun onDeviceRetrievalHelperReady(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
-    fun onCommunicationError(msg: String)
-    fun onNewDeviceRequest(request: String?, sessionsTranscript: ByteArray)
+    fun onDeviceConnecting()
+    fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
+    fun onError(msg: String)
+    fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray)
     fun onDeviceDisconnected(transportSpecificTermination: Boolean)
 }


### PR DESCRIPTION
## Short description

QrEngagementListener has methods name equals to IOS.

```kotlin
interface QrEngagementListener {
    fun onDeviceConnecting()
    fun onDeviceConnected(deviceRetrievalHelper: DeviceRetrievalHelperWrapper)
    fun onError(error: Throwable)
    fun onDocumentRequestReceived(request: String?, sessionsTranscript: ByteArray)
    fun onDeviceDisconnected(transportSpecificTermination: Boolean)
}
```

## List of changes proposed in this pull request

- Events alignment for both platforms

