### PR TITLE
feat: [IWP-125] aligned android behaviour to unit test one

### DIFF
--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/CborViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/CborViewViewModel.kt
@@ -34,6 +34,14 @@ class CborViewViewModel : ViewModel() {
     var errorToShow by mutableStateOf<Pair<String, String>?>(null)
     fun decodeMDoc() {
         CBorParser(this.cborText).documentsCborToJson(separateElementIdentifier, onComplete = {
+            CborLogger.i(
+                "x5chain",
+                JSONObject(it).optJSONArray("documents")?.optJSONObject(0)
+                    ?.optJSONObject("issuerSigned")
+                    ?.optJSONObject("issuerAuth")
+                    ?.optJSONArray("unprotectedHeader")
+                    ?.toString().orEmpty()
+            )
             this@CborViewViewModel.model = DocsModel.fromJson(JSONObject(it))
             this@CborViewViewModel.errorToShow = null
         }) { ex ->

--- a/cbor/src/main/java/it/pagopa/io/wallet/cbor/extensions/extensions.kt
+++ b/cbor/src/main/java/it/pagopa/io/wallet/cbor/extensions/extensions.kt
@@ -68,7 +68,7 @@ internal fun CBORObject.extractContentType() = this.AsString()
 internal fun CBORObject.extractX5U() = this.AsString()
 internal fun CBORObject.toB64() = Base64.getUrlEncoder().encodeToString(this.GetByteString())
 internal fun CBORObject.toCertificates(): JSONArray {
-    val base64Certificates = mutableListOf<String>()
+    val base64Certificates = JSONArray()
     try {
         if (this.type == CBORType.Array) {
             // Handle the case where the CBOR object is an array of byte strings
@@ -76,12 +76,12 @@ internal fun CBORObject.toCertificates(): JSONArray {
                 // Extract each byte string from the array
                 val certBytes = this[i].GetByteString()
                 val encodedCert = Base64.getUrlEncoder().encodeToString(certBytes)
-                base64Certificates.add(encodedCert)
+                base64Certificates.put(encodedCert)
             }
         } else if (this.type == CBORType.ByteString) {
             // Handle the case where the CBOR object is a single ByteString containing multiple certificates
             val encodedCert = Base64.getUrlEncoder().encodeToString(this.GetByteString())
-            base64Certificates.add(encodedCert)
+            base64Certificates.put(encodedCert)
         } else {
             CborLogger.e(
                 "Parsing Unprotected header",
@@ -94,9 +94,5 @@ internal fun CBORObject.toCertificates(): JSONArray {
             "Error parsing certificates: ${e.message}"
         )
     }
-    val arrayBack = JSONArray()
-    base64Certificates.forEach {
-        arrayBack.put(it)
-    }
-    return arrayBack
+    return base64Certificates
 }

--- a/cbor/src/main/java/it/pagopa/io/wallet/cbor/extensions/extensions.kt
+++ b/cbor/src/main/java/it/pagopa/io/wallet/cbor/extensions/extensions.kt
@@ -8,6 +8,7 @@ import it.pagopa.io.wallet.cbor.CborLogger
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.ASN1Sequence
+import org.json.JSONArray
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.util.Base64
@@ -66,7 +67,7 @@ internal fun CBORObject.extractCrit() = this.values.map { it.AsString() }
 internal fun CBORObject.extractContentType() = this.AsString()
 internal fun CBORObject.extractX5U() = this.AsString()
 internal fun CBORObject.toB64() = Base64.getUrlEncoder().encodeToString(this.GetByteString())
-internal fun CBORObject.toCertificates(): List<String> {
+internal fun CBORObject.toCertificates(): JSONArray {
     val base64Certificates = mutableListOf<String>()
     try {
         if (this.type == CBORType.Array) {
@@ -93,5 +94,9 @@ internal fun CBORObject.toCertificates(): List<String> {
             "Error parsing certificates: ${e.message}"
         )
     }
-    return base64Certificates
+    val arrayBack = JSONArray()
+    base64Certificates.forEach {
+        arrayBack.put(it)
+    }
+    return arrayBack
 }


### PR DESCRIPTION
## Short description

Android was not giving back a JSON array while certificates were a list.

## List of changes proposed in this pull request

Before:
```kotlin
internal fun CBORObject.toCertificates(): List<String> 
```
After:
```kotlin
internal fun CBORObject.toCertificates(): JSONArray 
```
Now android gives back a real instance of JSON Array instead of a string list. a ```kotlin List<String>``` was enough to have the expected behaviour while doing unit test but not while using the algorithm into an android device.

## Example with unit test mock now aligned in android:

```json
{
  "unprotectedHeader": [
    {
      "x5chain": [
        "MIICgTCCAiagAwIBAgIJFkrlmQLcBRBk. Etc....."
      ]
    }
  ]
}
```
unit test is `test documents json element identifier separated`into CborParserTest.
