### PR TITLE
refactor: [IWP-128] added SessionDataStatus enum to manage errorResponse

### DIFF
--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/MasterViewViewModel.kt
@@ -13,6 +13,7 @@ import it.pagopa.io.wallet.proximity.qr_code.QrEngagement
 import it.pagopa.io.wallet.proximity.qr_code.QrEngagementListener
 import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator
+import it.pagopa.io.wallet.proximity.session_data.SessionDataStatus
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 import it.pagopa.iso_android.R
 import it.pagopa.iso_android.qr_code.QrCode
@@ -197,10 +198,11 @@ class MasterViewViewModel(
                         this@MasterViewViewModel.loader.value = null
                         dialogFailure(message)
                         val isNoDocFound = message == "no doc found"
-                        if (isNoDocFound)
-                            qrCodeEngagement.sendErrorResponse()
+                        val toSend = if (isNoDocFound)
+                            SessionDataStatus.ERROR_SESSION_ENCRYPTION
                         else
-                            qrCodeEngagement.sendErrorResponseNoData()
+                            SessionDataStatus.ERROR_CBOR_DECODING
+                        qrCodeEngagement.sendErrorResponse(toSend)
                     }
                 }
             )
@@ -272,7 +274,7 @@ class MasterViewViewModel(
                 ProximityLogger.i("request", request.toString())
                 this@MasterViewViewModel.request = request.orEmpty()
                 if (request == null) {
-                    qrCodeEngagement.sendErrorResponse()
+                    qrCodeEngagement.sendErrorResponse(SessionDataStatus.ERROR_CBOR_DECODING)
                     _shouldGoBack.value = true
                 } else
                     manageRequestFromDeviceUi(sessionsTranscript)

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/QrEngagement.kt
@@ -22,6 +22,7 @@ import it.pagopa.io.wallet.proximity.request.RequestWrapper
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import it.pagopa.io.wallet.proximity.retrieval.connectionMethods
 import it.pagopa.io.wallet.proximity.retrieval.transportOptions
+import it.pagopa.io.wallet.proximity.session_data.SessionDataStatus
 import it.pagopa.io.wallet.proximity.toRequest
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -274,22 +275,11 @@ class QrEngagement private constructor(
     /**
      * Use this method to send a generic error message
      */
-    fun sendErrorResponse() {
+    fun sendErrorResponse(sessionDataStatus: SessionDataStatus) {
         if (deviceRetrievalHelper == null) return
         deviceRetrievalHelper!!.sendResponse(
             null,
-            Constants.SESSION_DATA_STATUS_ERROR_CBOR_DECODING
-        )
-    }
-
-    /**
-     * Use this method to send a generic error message
-     */
-    fun sendErrorResponseNoData() {
-        if (deviceRetrievalHelper == null) return
-        deviceRetrievalHelper!!.sendResponse(
-            null,
-            Constants.DEVICE_RESPONSE_STATUS_GENERAL_ERROR
+            sessionDataStatus.value
         )
     }
 

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/session_data/SessionDataStatus.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/session_data/SessionDataStatus.kt
@@ -1,5 +1,14 @@
 package it.pagopa.io.wallet.proximity.session_data
-
+/**
+**Table 20 — SessionData status codes**
+__________________________________________________________________________
+| Status code | Description               | Action required                 |
+--------------------------------------------------------------------------
+|     10      | Error: session encryption | The session shall be terminated.|
+|     11      | Error: CBOR decoding      | The session shall be terminated.|
+|     20      | Session termination       | The session shall be terminated.|
+--------------------------------------------------------------------------
+ */
 enum class SessionDataStatus(val value: Long) {
     ERROR_SESSION_ENCRYPTION(10L),
     ERROR_CBOR_DECODING(11L),

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/session_data/SessionDataStatus.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/session_data/SessionDataStatus.kt
@@ -1,0 +1,7 @@
+package it.pagopa.io.wallet.proximity.session_data
+
+enum class SessionDataStatus(val value: Long) {
+    ERROR_SESSION_ENCRYPTION(10L),
+    ERROR_CBOR_DECODING(11L),
+    SESSION_TERMINATION(20L)
+}


### PR DESCRIPTION
## Short description

QrEngagement.sendErrorResponseNoData deleted.
QrEngagement.sendErrorResponse now has one param SessionDataStatus.

**Table 20 — SessionData status codes**
__________________________________________________________________________
| Status code | Description                 | Action required                 |
--------------------------------------------------------------------------
|     10      | Error: session encryption | The session shall be terminated.|
|     11      | Error: CBOR decoding      | The session shall be terminated.|
|     20      | Session termination         | The session shall be terminated.|
--------------------------------------------------------------------------
```kotlin
enum class SessionDataStatus(val value: Long) {
    ERROR_SESSION_ENCRYPTION(10L),
    ERROR_CBOR_DECODING(11L),
    SESSION_TERMINATION(20L)
}
```