### PR TITLE
feat: [IWP-144] manage documents in app while transfering with NFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,24 +203,8 @@ data class NfcRetrievalMethod(
 Extend `NfcEngagementService` in your application module:
 
 ```kotlin
-class MyNfcEngagementService : NfcEngagementService() {
-
-    /**
-     * Override this method to customize which fields are accepted from the verifier's request.
-     * The default implementation accepts all requested fields.
-     *
-     * @param jsonString the raw JSON request string
-     * @return a JSON string with the fields to disclose (value = true to share, omit to reject)
-     */
-    override fun nfcOnlyFieldAcceptation(jsonString: String): String {
-        // Default: accept all fields as requested.
-        // You can filter specific fields by not including them in the returned JSON.
-        return super.nfcOnlyFieldAcceptation(jsonString)
-    }
-}
+class MyNfcEngagementService : NfcEngagementService()
 ```
-
-The `nfcOnlyFieldAcceptation` method receives the verifier's device request as a JSON string and must return a JSON object mapping each requested document namespace and field to `true` (disclose) or omitting it (reject). This is the single customisation point for field-level disclosure policy.
 
 #### Step 2 — Declare the service in `AndroidManifest.xml`
 
@@ -257,16 +241,13 @@ NfcEngagementEventBus.setupNfcService(
             clearBleCache = true
         )
     ),
-    documents = docManager.getAllDocuments(),  // List<Document>
-    alias = "myKeyAlias",
-    readerTrustStore = listOf(listOf(R.raw.eudi_pid_issuer_ut))  // raw resource certificates
+    readerTrustStore = listOf(listOf(R.raw.eudi_pid_issuer_ut)),  // raw resource certificates
+    inactivityTimeoutSeconds = 15
 )
 
 // NFC-only (engagement + data transfer entirely over NFC)
 NfcEngagementEventBus.setupNfcService(
     retrievalMethods = listOf(NfcRetrievalMethod()),
-    documents = docManager.getAllDocuments(),
-    alias = "myKeyAlias",
     readerTrustStore = listOf(listOf(R.raw.eudi_pid_issuer_ut))
 )
 ```
@@ -332,9 +313,8 @@ viewModelScope.launch {
                 //   (in NFC-only mode the response must be sent automatically,
                 //    without waiting for user confirmation)
                 val request = event.request.orEmpty()
-                if (!event.onlyNfc)
-                    // Show a consent UI to the user before disclosing data
-                    manageRequestFromDeviceUi(event.sessionTranscript)
+                // Show a consent UI to the user before disclosing data
+                manageRequestFromDeviceUi(event.sessionTranscript, event.onlyNfc)
             }
 
             is NfcEngagementEvent.Disconnected -> {
@@ -363,7 +343,7 @@ viewModelScope.launch {
 
 #### Step 6 — Build and send the response
 
-Once the user has consented (or immediately in NFC-only mode), use `ResponseGenerator` to build the CBOR response and send it:
+Once the user has consented (or immediately in NFC-only mode), use `ResponseGenerator` to build the CBOR response and send it, onlyNfc means that request is from a fully NFC exchange:
 
 ```kotlin
 ResponseGenerator(sessionsTranscript = sessionTranscript)
@@ -373,6 +353,11 @@ ResponseGenerator(sessionsTranscript = sessionTranscript)
         response = object : ResponseGenerator.Response {
             override fun onResponseGenerated(response: ByteArray) {
                 // Send via DeviceRetrievalHelperWrapper (NFC+BLE or NFC-only)
+                if(onlyNfc){
+                   val ok = NfcEngagementEventBus.sendDocumentResponse(response)
+                   ProximityLogger.i("RESPONSE SENT", ok.toString())
+                   return
+                }
                 deviceConnected?.sendResponse(response, SessionDataStatus.SESSION_DATA.value)
             }
             override fun onError(message: String) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "it.pagopa.iso_android"
-    compileSdk = 35
+    compileSdk = 36
 
     signingConfigs {
         create("app-debug") {
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         applicationId = "it.pagopa.iso_android"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/it/pagopa/iso_android/MainActivity.kt
+++ b/app/src/main/java/it/pagopa/iso_android/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.compose.rememberNavController
 import it.pagopa.io.wallet.cbor.CborLogger
-import it.pagopa.io.wallet.proximity.KindOfLog
 import it.pagopa.io.wallet.proximity.ProximityLogger
 import it.pagopa.iso_android.navigation.IsoAndroidPocNavHost
 import it.pagopa.iso_android.navigation.menu.DrawerBody

--- a/app/src/main/java/it/pagopa/iso_android/nfc/AppNfcEngagementService.kt
+++ b/app/src/main/java/it/pagopa/iso_android/nfc/AppNfcEngagementService.kt
@@ -1,34 +1,5 @@
 package it.pagopa.iso_android.nfc
 
 import it.pagopa.io.wallet.proximity.nfc.NfcEngagementService
-import org.json.JSONObject
 
-class AppNfcEngagementService : NfcEngagementService() {
-    // HERE WE CAN DECIDE TO not send some fields respect the request from reader or to send all putting it to true
-    override fun nfcOnlyFieldAcceptation(
-        jsonString: String
-    ): String {
-        val originalReq = JSONObject(jsonString).optJSONObject("request")
-        val jsonAccepted = JSONObject()
-        originalReq?.keys()?.forEach { docType ->
-            //here docType is I.E.: org.iso.18013.5.1.mDL
-            //in case with Only NFC mode you don't allow to send euPid:
-            //if (docType != DocType.EU_PID.value) {
-                originalReq.optJSONObject(docType)?.let { json ->
-                    val keyJson = JSONObject()
-                    json.keys().forEach { key ->
-                        json.optJSONObject(key)?.let { internalJson ->
-                            val internalNewJson = JSONObject()
-                            internalJson.keys().forEach { dataKey ->
-                                internalNewJson.put(dataKey, true)
-                            }
-                            keyJson.put(key, internalNewJson)
-                        }
-                    }
-                    jsonAccepted.put(docType, keyJson)
-                }
-            //and close it here... }
-        }
-        return jsonAccepted.toString()
-    }
-}
+class AppNfcEngagementService : NfcEngagementService()

--- a/app/src/main/java/it/pagopa/iso_android/ui/view/Home.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view/Home.kt
@@ -91,15 +91,11 @@ fun HomeView(
                                         clearBleCache = true
                                     )
                                 ),
-                                docManager.gelAllDocuments(),
-                                "pagoPa",
                                 listOf(listOf(R.raw.eudi_pid_issuer_ut))
                             )
 
                             is HomeDestination.MasterNfcExchange -> NfcEngagementEventBus.setupNfcService(
                                 retrievalMethods = listOf(NfcRetrievalMethod()),
-                                docManager.gelAllDocuments(),
-                                "pagoPa",
                                 listOf(listOf(R.raw.eudi_pid_issuer_ut))
                             )
 
@@ -111,8 +107,6 @@ fun HomeView(
                                         clearBleCache = true
                                     )
                                 ),
-                                docManager.gelAllDocuments(),
-                                "pagoPa",
                                 listOf(listOf(R.raw.eudi_pid_issuer_ut))
                             )
 
@@ -120,8 +114,6 @@ fun HomeView(
                                 retrievalMethods = listOf(
                                     NfcRetrievalMethod()
                                 ),
-                                docManager.gelAllDocuments(),
-                                "pagoPa",
                                 listOf(listOf(R.raw.eudi_pid_issuer_ut))
                             )
                         }

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
@@ -113,8 +113,8 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
                         this@BaseEngagementViewModel.loader.value = null
                         dialogFailure(message)
                         if (onlyNfc) {
-                            val ok =NfcEngagementEventBus.
-                                sendDocumentResponse(NfcEngagementService.RESPONSE_GENERATION_ERROR)
+                            val ok =
+                                NfcEngagementEventBus.sendDocumentResponse(NfcEngagementService.RESPONSE_GENERATION_ERROR)
                             ProximityLogger.i("RESPONSE SENT", ok.toString())
                             return
                         }
@@ -185,25 +185,29 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
             }
         }
         this.loader.value = null
-        this.dialogText = sb.toString()
-        dialog.value = AppDialog(
-            title = resources.getString(R.string.warning),
-            description = this.dialogText,
-            button = AppDialog.DialogButton(
-                resources.getString(R.string.ok),
-                onClick = {
-                    this.dialog.value = null
-                    shareInfo(sessionsTranscript, onlyNfc)
-                },
-            ),
-            secondButton = AppDialog.DialogButton(
-                resources.getString(R.string.no),
-                onClick = {
-                    this.dialog.value = null
-                    _shouldGoBack.value = true
-                },
+        if (onlyNfc)
+            shareInfo(sessionsTranscript, true)
+        else {
+            this.dialogText = sb.toString()
+            dialog.value = AppDialog(
+                title = resources.getString(R.string.warning),
+                description = this.dialogText,
+                button = AppDialog.DialogButton(
+                    resources.getString(R.string.ok),
+                    onClick = {
+                        this.dialog.value = null
+                        shareInfo(sessionsTranscript, onlyNfc)
+                    },
+                ),
+                secondButton = AppDialog.DialogButton(
+                    resources.getString(R.string.no),
+                    onClick = {
+                        this.dialog.value = null
+                        _shouldGoBack.value = true
+                    },
+                )
             )
-        )
+        }
     }
 
     private fun dialogFailure(message: String) {

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
@@ -59,7 +59,7 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
         return jsonAccepted.toString()
     }
 
-    protected fun shareInfo(sessionsTranscript: ByteArray) {
+    protected fun shareInfo(sessionsTranscript: ByteArray, onlyNfc: Boolean) {
         if (!keyExists())
             generateKey()
         this.loader.value = resources.getString(R.string.sending_doc)
@@ -98,13 +98,14 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
                             "RESPONSE TO SEND",
                             Base64.encodeToString(response, Base64.NO_WRAP)
                         )
+                        if (onlyNfc) {
+                            val ok = NfcEngagementEventBus.sendDocumentResponse(response)
+                            ProximityLogger.i("RESPONSE SENT", ok.toString())
+                            return
+                        }
                         this@BaseEngagementViewModel.engagement?.sendResponse(response) ?: run {
                             deviceConnected.sendSessionTermination(response)
                         }
-                        ProximityLogger.i(
-                            "RESPONSE TO SEND",
-                            Base64.encodeToString(response, Base64.NO_WRAP)
-                        )
                     }
 
                     override fun onError(message: String) {
@@ -125,7 +126,8 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
     }
 
     protected fun manageRequestFromDeviceUi(
-        sessionsTranscript: ByteArray
+        sessionsTranscript: ByteArray,
+        onlyNfc: Boolean = false
     ) {
         val sb = StringBuilder().apply {
             append("${resources.getString(R.string.share_info_title)}:\n")
@@ -184,7 +186,7 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
                 resources.getString(R.string.ok),
                 onClick = {
                     this.dialog.value = null
-                    shareInfo(sessionsTranscript)
+                    shareInfo(sessionsTranscript, onlyNfc)
                 },
             ),
             secondButton = AppDialog.DialogButton(
@@ -239,11 +241,9 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
 
                     is NfcEngagementEvent.DocumentRequestReceived -> {
                         val request = event.request
-                        event.sessionTranscript
                         ProximityLogger.i("request", request.toString())
                         this@BaseEngagementViewModel.request = request.orEmpty()
-                        if (!event.onlyNfc)
-                            manageRequestFromDeviceUi(event.sessionTranscript)
+                        manageRequestFromDeviceUi(event.sessionTranscript, event.onlyNfc)
                     }
 
                     is NfcEngagementEvent.Disconnected -> {

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
@@ -11,6 +11,7 @@ import it.pagopa.io.wallet.proximity.engagement.Engagement
 import it.pagopa.io.wallet.proximity.engagement.EngagementListener
 import it.pagopa.io.wallet.proximity.nfc.NfcEngagementEvent
 import it.pagopa.io.wallet.proximity.nfc.NfcEngagementEventBus
+import it.pagopa.io.wallet.proximity.nfc.NfcEngagementService
 import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.response.ResponseGenerator
 import it.pagopa.io.wallet.proximity.retrieval.sendErrorResponse
@@ -111,6 +112,12 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
                     override fun onError(message: String) {
                         this@BaseEngagementViewModel.loader.value = null
                         dialogFailure(message)
+                        if (onlyNfc) {
+                            val ok =NfcEngagementEventBus.
+                                sendDocumentResponse(NfcEngagementService.RESPONSE_GENERATION_ERROR)
+                            ProximityLogger.i("RESPONSE SENT", ok.toString())
+                            return
+                        }
                         val isNoDocFound = message == "no doc found"
                         val toSend = if (isNoDocFound)
                             SessionDataStatus.ERROR_SESSION_ENCRYPTION

--- a/cbor/build.gradle.kts
+++ b/cbor/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "it.pagopa.io.wallet.cbor"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26

--- a/proximity/build.gradle.kts
+++ b/proximity/build.gradle.kts
@@ -13,7 +13,7 @@ tasks.matching { it.name.contains("javaDocReleaseGeneration", ignoreCase = true)
 
 android {
     namespace = "it.pagopa.io.wallet.proximity"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
@@ -40,7 +40,7 @@ android {
 }
 
 mavenPublishing {
-    coordinates("it.pagopa.io.wallet.proximity", "proximity", "2.4.0")
+    coordinates("it.pagopa.io.wallet.proximity", "proximity", "2.4.1")
 
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagement.kt
@@ -68,6 +68,7 @@ internal class NfcEngagement(
     }
 
     override fun close() {
+        ProximityLogger.i(NfcEngagement::class.java.name, "CLOSING NFC CONNECTION")
         try {
             if (deviceRetrievalHelper != null)
                 deviceRetrievalHelper!!.disconnect()
@@ -97,8 +98,7 @@ internal class NfcEngagement(
          */
         fun build(
             context: Context,
-            retrievalMethods: List<DeviceRetrievalMethod>,
-            whatToDoWithRequest: (String)->String
+            retrievalMethods: List<DeviceRetrievalMethod>
         ) = NfcEngagement(context).apply {
             this@apply.retrievalMethods = retrievalMethods
             this@apply.nfcEngagementBuilder = NfcEngagementHelperRefactor.Builder(
@@ -106,8 +106,7 @@ internal class NfcEngagement(
                 this@apply.eDevicePrivateKey,
                 this@apply.retrievalMethods,
                 this@apply.nfcEngagementListener,
-                context.mainExecutor(),
-                whatToDoWithRequest
+                context.mainExecutor()
             ).staticHandoverWith(this@apply.retrievalMethods.connectionMethods)
         }
     }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementEvent.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementEvent.kt
@@ -1,7 +1,6 @@
 package it.pagopa.io.wallet.proximity.nfc
 
 import com.android.identity.crypto.EcPrivateKey
-import it.pagopa.io.wallet.cbor.model.Document
 import it.pagopa.io.wallet.proximity.nfc.utils.OnlyNfcEvents
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
@@ -24,12 +23,12 @@ sealed class NfcEngagementEvent {
     data object DocumentSent : NfcEngagementEvent()
 }
 
+
 internal sealed class ServiceEvents {
     data class SetupReady(
         val retrievalMethods: List<DeviceRetrievalMethod>,
-        val documents: List<Document>?,
-        val alias: String?,
-        val readerTrustStore: List<List<Any>>?
+        val readerTrustStore: List<List<Any>>?,
+        val inactivityTimeout: Int = 15
     ) : ServiceEvents()
 
     data class QrCodeDeviceEngagement(

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementEventBus.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementEventBus.kt
@@ -1,10 +1,11 @@
 package it.pagopa.io.wallet.proximity.nfc
 
 import com.android.identity.crypto.EcPrivateKey
-import it.pagopa.io.wallet.cbor.model.Document
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**Singleton event bus using SharedFlow for NFC notifications.  */
 object NfcEngagementEventBus {
@@ -14,39 +15,59 @@ object NfcEngagementEventBus {
         extraBufferCapacity = 1 // Optional: prevents lost fast events
     )
     val events = _events.asSharedFlow()
-    private val _internalEvent = MutableSharedFlow<ServiceEvents>(
-        replay = 1,
-        extraBufferCapacity = 0
+
+    private val _setupEvent = MutableStateFlow<ServiceEvents.SetupReady?>(null)
+    internal val setupEvent = _setupEvent.asStateFlow()
+
+
+    // QrCode: no replay, one-shot
+    private val _qrEvent = MutableSharedFlow<ServiceEvents.QrCodeDeviceEngagement>(
+        replay = 0,
+        extraBufferCapacity = 1
     )
-    internal val internalEvent = _internalEvent.asSharedFlow()
+    internal val qrEvent = _qrEvent.asSharedFlow()
+    private val _responseEvent = MutableSharedFlow<ByteArray>(
+        replay = 0,
+        extraBufferCapacity = 1
+    )
+    val responseEvent = _responseEvent.asSharedFlow()
 
     // Use outside coroutines (e.g., in listeners); non-suspending.
     internal fun tryEmit(event: NfcEngagementEvent) {
         _events.tryEmit(event)
     }
 
-    /**It emits the event for the [NfcEngagementService] to setup engagement
+    internal fun resetSetup() {
+        _setupEvent.tryEmit(null)
+    }
+
+    /**It emits the event for the [NfcEngagementService] to set up engagement
      * @return true-> if event is sent correctly*/
     fun setupNfcService(
         retrievalMethods: List<DeviceRetrievalMethod>,
-        documents: List<Document>?=null,
-        alias: String?=null,
-        readerTrustStore: List<List<Any>>?=null
+        readerTrustStore: List<List<Any>>? = null,
+        inactivityTimeoutSeconds: Int = 15
     ): Boolean {
-        return _internalEvent.tryEmit(
+        return _setupEvent.tryEmit(
             ServiceEvents.SetupReady(
                 retrievalMethods,
-                documents,
-                alias,
-                readerTrustStore
+                readerTrustStore,
+                inactivityTimeoutSeconds
             )
         )
     }
 
     /**
-     * It emits the event for the [NfcEngagementService] to setup engagement
+     * It emits the event for the [NfcEngagementService] to send a document response
+     * @return true-> if event is sent correctly*/
+    fun sendDocumentResponse(response: ByteArray): Boolean {
+        return _responseEvent.tryEmit(response)
+    }
+
+    /**
+     * It emits the event for the [NfcEngagementService] to set up engagement
      * @return true-> if event is sent correctly*/
     internal fun setupDeviceEngagementFromQr(deviceEngagementSetup: Pair<ByteArray, EcPrivateKey>) {
-        _internalEvent.tryEmit(ServiceEvents.QrCodeDeviceEngagement(deviceEngagementSetup))
+        _qrEvent.tryEmit(ServiceEvents.QrCodeDeviceEngagement(deviceEngagementSetup))
     }
 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
@@ -24,10 +24,6 @@ import com.android.identity.mdoc.sessionencryption.SessionEncryption
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity.util.toHex
-import it.pagopa.io.wallet.cbor.model.DocType
-import it.pagopa.io.wallet.cbor.model.Document
-import it.pagopa.io.wallet.cbor.model.EU_PID_DOCTYPE
-import it.pagopa.io.wallet.cbor.model.MDL_DOCTYPE
 import it.pagopa.io.wallet.proximity.ProximityLogger
 import it.pagopa.io.wallet.proximity.document.reader_auth.ReaderTrustStore
 import it.pagopa.io.wallet.proximity.nfc.apdu.CommandApdu
@@ -38,9 +34,7 @@ import it.pagopa.io.wallet.proximity.nfc.utils.NfcEngagementHelperUtils
 import it.pagopa.io.wallet.proximity.nfc.utils.OnlyNfcEvents
 import it.pagopa.io.wallet.proximity.parser.DeviceRequestParserRefactor
 import it.pagopa.io.wallet.proximity.qr_code.toReaderAuthWith
-import it.pagopa.io.wallet.proximity.request.DocRequested
 import it.pagopa.io.wallet.proximity.request.RequestWrapper
-import it.pagopa.io.wallet.proximity.response.ResponseGenerator
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import it.pagopa.io.wallet.proximity.retrieval.transportOptions
 import it.pagopa.io.wallet.proximity.toRequest
@@ -76,11 +70,10 @@ import java.util.concurrent.Executor
 class NfcEngagementHelperRefactor private constructor(
     private val context: Context,
     private val eDeviceKey: EcPrivateKey,
-    private val retrievalMethods: List<DeviceRetrievalMethod>,
     private val listener: Listener,
-    private val executor: Executor,
-    private val whatToDoWithRequest: (String) -> String
+    private val executor: Executor
 ) {
+    internal var retrievalMethods: List<DeviceRetrievalMethod> = listOf()
     private var staticHandoverConnectionMethods: List<ConnectionMethod>? = null
     private var transports = mutableListOf<DataTransport>()
     private var envelopeBuffer = ByteArrayOutputStream()
@@ -88,8 +81,6 @@ class NfcEngagementHelperRefactor private constructor(
     private var responseOffset: Int = 0
     private var useExtendedLength: Boolean = false
     private var readerTrustStores: List<ReaderTrustStore>? = listOf()
-    private var docs: Array<Document> = arrayOf()
-    private var alias = ""
     private var sessionEncryption: SessionEncryption? = null
     private var deviceEngagementFromQr: ByteArray? = null
 
@@ -127,12 +118,8 @@ class NfcEngagementHelperRefactor private constructor(
     }
 
 
-    fun withDocs(docs: Array<Document>) = apply {
-        this.docs = docs
-    }
-
-    fun withAlias(alias: String) = apply {
-        this.alias = alias
+    private fun withRetrievalMethods(retrievalMethods: List<DeviceRetrievalMethod>) = apply {
+        this.retrievalMethods = retrievalMethods
     }
 
     private fun resetApduDataRetrievalState() {
@@ -314,7 +301,7 @@ class NfcEngagementHelperRefactor private constructor(
      * @param apdu The APDU that was received from the remote device.
      * @return a byte-array containing the response APDU a boolean which means if process is ended or not.
      */
-    fun nfcProcessCommandApdu(apdu: ByteArray): Pair<ByteArray, Boolean> {
+    fun nfcProcessCommandApdu(apdu: ByteArray): Pair<ByteArray?, Boolean> {
         if (ProximityLogger.enabled) {
             ProximityLogger.d(TAG, "nfcProcessCommandApdu: apdu: ${Utils.bytesToHex(apdu)}")
         }
@@ -849,9 +836,63 @@ class NfcEngagementHelperRefactor private constructor(
         }
     }
 
+    private var le = 0
+
+    fun processDocResponse(response: ByteArray): Pair<ByteArray, Boolean> {
+        ProximityLogger.d(
+            TAG,
+            "ENVELOPE: Response size=${response.size}"
+        )
+        val messageBack = sessionEncryption!!.encryptMessage(
+            response,
+            Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
+        )
+        ProximityLogger.i(TAG, "ENVELOPE: apduCommand.le=$le, fileMaxLength=$fileMaxLength")
+        // Encapsulating in DO'53'
+        responseBuffer = ByteString(messageBack).encapsulateInDo53().toByteArray()
+        responseOffset = 0
+        ProximityLogger.i(
+            TAG,
+            "ENVELOPE: Response buffer size=${responseBuffer!!.size}, useExtendedLength=$useExtendedLength"
+        )
+        val unlimited = (le == 0 && useExtendedLength)
+        val chunkSize =
+            if (unlimited) responseBuffer!!.size else responseBuffer!!.size.coerceAtMost(
+                fileMaxLength.toInt()
+            )
+        val chunk = responseBuffer!!.copyOfRange(responseOffset, responseOffset + chunkSize)
+        responseOffset += chunkSize
+        // If oversize, responding with 61xx and waiting for GET RESPONSE
+        if (NfcEngagementHelperUtils.shouldUseGetResponse(
+                responseBuffer!!,
+                fileMaxLength.toInt()
+            )
+        ) {
+            val sw = if (useExtendedLength) byteArrayOf(0x61, 0x00) else byteArrayOf(
+                0x61,
+                0xFF.toByte()
+            )
+            ProximityLogger.d(
+                TAG,
+                "ENVELOPE: Response too large, sending SW=${Utils.bytesToHex(sw)}"
+            )
+            return (chunk + sw) to false
+        } else {
+            val response = responseBuffer!! + byteArrayOf(0x90.toByte(), 0x00.toByte())
+            ProximityLogger.i("SENDING", response.toHex())
+            ProximityLogger.d(
+                TAG,
+                "ENVELOPE: Response fits, sending ${response.size} bytes directly"
+            )
+            responseBuffer = null
+            NfcEngagementEventBus.tryEmit(NfcEngagementEvent.DocumentSent)
+            return response to true
+        }
+    }
+
     // ENVELOPE (INS=C3)
     @OptIn(ExperimentalStdlibApi::class)
-    private fun handleEnvelope(apdu: ByteArray): Pair<ByteArray, Boolean> {
+    private fun handleEnvelope(apdu: ByteArray): Pair<ByteArray?, Boolean> {
         ProximityLogger.i(TAG, "ENVELOPE - APDU size: ${apdu.size}")
         // INS = C3, P1P2=0000, datadata=DO'53' o part of; Nc=0 for "end of data string"
         if (apdu.size < 4 || (apdu[1].toInt() and 0xff) != 0xC3) {
@@ -867,7 +908,7 @@ class NfcEngagementHelperRefactor private constructor(
         ProximityLogger.i("useExtendedLength", useExtendedLength.toString())
         ProximityLogger.i("APDU[0]", apdu[0].toHexString())
         envelopeBuffer.write(apduCommand.payload.toByteArray())
-        return when (apduCommand.cla) {
+        when (apduCommand.cla) {
             0x00 -> {
                 NfcEngagementEventBus.tryEmit(
                     NfcEngagementEvent.NfcOnlyEventListener(
@@ -877,7 +918,7 @@ class NfcEngagementHelperRefactor private constructor(
                 val fullRequest = envelopeBuffer.toByteArray()
                 ProximityLogger.i(TAG, "ENVELOPE: Full request collected, size=${fullRequest.size}")
                 envelopeBuffer.reset()
-                ProximityLogger.i("REQ BEF DO 53", fullRequest.toHex())
+                le = apduCommand.le
                 val requestEncrypted: ByteArray = try {
                     ByteString(fullRequest).extractFromDo53().toByteArray()
                 } catch (e: Throwable) {
@@ -885,70 +926,22 @@ class NfcEngagementHelperRefactor private constructor(
                     return NfcUtil.STATUS_WORD_WRONG_PARAMETERS to true
                 }
                 ProximityLogger.d(TAG, "ENVELOPE: Encrypted request size=${requestEncrypted.size}")
-
-                val response: ByteArray = try {
+                val response: ByteArray? = try {
                     processReaderRequest(requestEncrypted)
                 } catch (e: Throwable) {
                     ProximityLogger.e(TAG, "ENVELOPE: Error processing request: ${e.message}")
                     return NfcUtil.STATUS_WORD_FILE_NOT_FOUND to true
                 }
-                ProximityLogger.d(
-                    TAG,
-                    "ENVELOPE: Response size=${response.size}"
-                )
-                val messageBack = sessionEncryption!!.encryptMessage(
-                    response,
-                    Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
-                )
-                val le = apduCommand.le
-                ProximityLogger.i(TAG, "ENVELOPE: apduCommand.le=$le, fileMaxLength=$fileMaxLength")
-                // Encapsulating in DO'53'
-                responseBuffer = ByteString(messageBack).encapsulateInDo53().toByteArray()
-                responseOffset = 0
-                ProximityLogger.i(
-                    TAG,
-                    "ENVELOPE: Response buffer size=${responseBuffer!!.size}, useExtendedLength=$useExtendedLength"
-                )
-                val unlimited = (le == 0 && useExtendedLength)
-                val chunkSize =
-                    if (unlimited) responseBuffer!!.size else responseBuffer!!.size.coerceAtMost(fileMaxLength.toInt())
-                val chunk = responseBuffer!!.copyOfRange(responseOffset, responseOffset + chunkSize)
-                responseOffset += chunkSize
-                // If oversize, responding with 61xx and waiting for GET RESPONSE
-                if (NfcEngagementHelperUtils.shouldUseGetResponse(
-                        responseBuffer!!,
-                        fileMaxLength.toInt()
-                    )
-                ) {
-                    val sw = if (useExtendedLength) byteArrayOf(0x61, 0x00) else byteArrayOf(
-                        0x61,
-                        0xFF.toByte()
-                    )
-                    ProximityLogger.d(
-                        TAG,
-                        "ENVELOPE: Response too large, sending SW=${Utils.bytesToHex(sw)}"
-                    )
-                    (chunk + sw) to false
-                } else {
-                    val response = responseBuffer!! + byteArrayOf(0x90.toByte(), 0x00.toByte())
-                    ProximityLogger.i("SENDING", response.toHex())
-                    ProximityLogger.d(
-                        TAG,
-                        "ENVELOPE: Response fits, sending ${response.size} bytes directly"
-                    )
-                    responseBuffer = null
-                    NfcEngagementEventBus.tryEmit(NfcEngagementEvent.DocumentSent)
-                    response to true
-                }
+                return response to false
             }
 
             0x10 -> {
                 ProximityLogger.d(TAG, "ENVELOPE: Buffer now has ${envelopeBuffer.size()} bytes")
                 // Waiting for final Envelope with Nc=0
-                NfcUtil.STATUS_WORD_OK to false
+                return NfcUtil.STATUS_WORD_OK to false
             }
 
-            else -> NfcUtil.STATUS_WORD_WRONG_PARAMETERS to false
+            else -> return NfcUtil.STATUS_WORD_WRONG_PARAMETERS to false
         }
     }
 
@@ -987,7 +980,7 @@ class NfcEngagementHelperRefactor private constructor(
 
     private fun processReaderRequest(
         requestCborEncrypted: ByteArray
-    ): ByteArray {
+    ): ByteArray? {
         ProximityLogger.i("requestCborEncrypted", requestCborEncrypted.toHex())
         val eReaderKey = Cbor.decode(requestCborEncrypted)
         try {
@@ -1051,37 +1044,7 @@ class NfcEngagementHelperRefactor private constructor(
                 onlyNfc = true
             )
         )
-        val disclosedDocuments = ArrayList<Document>()
-        val req = this.whatToDoWithRequest.invoke(jsonToSend.toString())
-        JSONObject(req).keys().forEach {
-            when {
-                DocType(it) == DocType.MDL -> disclosedDocuments.add(docs.first { doc -> doc.docType == MDL_DOCTYPE })
-                DocType(it) == DocType.EU_PID -> disclosedDocuments.add(docs.first { doc -> doc.docType == EU_PID_DOCTYPE })
-            }
-        }
-        val docRequested = disclosedDocuments.mapNotNull {
-            it.issuerSigned?.rawValue?.let { doc ->
-                DocRequested(
-                    issuerSignedContent = doc,
-                    alias = alias,
-                    docType = it.docType!!
-                )
-            }
-        }
-        docRequested.forEachIndexed { i, each ->
-            ProximityLogger.i(
-                "docRequested $i",
-                "Doc type: ${each.docType};\nAlias: ${each.alias};"
-            )
-        }
-        ProximityLogger.i("originalJson", jsonToSend.toString(3).orEmpty())
-        val (resp, itsOk) = ResponseGenerator(
-            sessionsTranscript = sessionTranscript
-        ).createResponse(
-            documents = docRequested.toTypedArray(),
-            fieldRequestedAndAccepted = req
-        )
-        return if (itsOk == "created") resp!! else NfcUtil.STATUS_WORD_FILE_NOT_FOUND
+        return null
     }
 
 
@@ -1097,9 +1060,9 @@ class NfcEngagementHelperRefactor private constructor(
             return NfcUtil.STATUS_WORD_WRONG_PARAMETERS to false
         }
 
-        val le = try{
+        val le = try {
             CommandApdu.decode(apdu).le
-        }catch (ex: Exception){
+        } catch (ex: Exception) {
             ProximityLogger.e(TAG, "GET RESPONSE: Error parsing APDU: ${ex.message}")
             fileMaxLength.toInt()
         }
@@ -1215,8 +1178,8 @@ class NfcEngagementHelperRefactor private constructor(
          * Called when the Handover Select message has been sent to the NFC tag reader.
          *
          *
-         * This is a good point for an app to notify the user that an mdoc transaction
-         * is about to to take place and they can start removing the device from the field.
+         * This is a good point for an app to notify the user that a mdoc transaction
+         * is about to take place, and they can start removing the device from the field.
          */
         fun onHandoverSelectMessageSent()
 
@@ -1265,17 +1228,14 @@ class NfcEngagementHelperRefactor private constructor(
         eDeviceKey: EcPrivateKey,
         retrievalMethods: List<DeviceRetrievalMethod>,
         listener: Listener,
-        executor: Executor,
-        whatToDoWithRequest: (String) -> String
+        executor: Executor
     ) {
         var helper = NfcEngagementHelperRefactor(
             context,
             eDeviceKey,
-            retrievalMethods,
             listener,
-            executor,
-            whatToDoWithRequest
-        )
+            executor
+        ).withRetrievalMethods(retrievalMethods)
 
         /**
          * Configures the builder so NFC Static Handover is used.
@@ -1290,7 +1250,7 @@ class NfcEngagementHelperRefactor private constructor(
         /**
          * Builds the [NfcEngagementHelperRefactor] and starts listening for connections.
          *
-         *]
+         *
          * and deactivation events using [.nfcOnDeactivated].
          *
          * @return the helper, ready to be used.

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
@@ -839,6 +839,9 @@ class NfcEngagementHelperRefactor private constructor(
     private var le = 0
 
     fun processDocResponse(response: ByteArray): Pair<ByteArray, Boolean> {
+        if(response.contentEquals(NfcUtil.STATUS_WORD_FILE_NOT_FOUND)){
+            return response to true
+        }
         ProximityLogger.d(
             TAG,
             "ENVELOPE: Response size=${response.size}"

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.CheckResult
+import com.android.identity.android.util.NfcUtil
 import com.android.identity.util.toHex
 import it.pagopa.io.wallet.proximity.ProximityLogger
 import it.pagopa.io.wallet.proximity.bluetooth.BleRetrievalMethod
@@ -102,6 +103,8 @@ abstract class NfcEngagementService : HostApduService() {
         @SuppressLint("StaticFieldLeak")
         private var nfcEngagement: NfcEngagement? = null
         private var inactivityTimeout = 15
+
+        val RESPONSE_GENERATION_ERROR = NfcUtil.STATUS_WORD_FILE_NOT_FOUND
 
         /**
          * Enable NFC engagement

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
@@ -12,16 +12,16 @@ import android.os.Looper
 import androidx.annotation.CheckResult
 import com.android.identity.util.toHex
 import it.pagopa.io.wallet.proximity.ProximityLogger
+import it.pagopa.io.wallet.proximity.bluetooth.BleRetrievalMethod
 import it.pagopa.io.wallet.proximity.engagement.EngagementListener
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import it.pagopa.io.wallet.proximity.wrapper.DeviceRetrievalHelperWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
-import org.json.JSONObject
 
 /**
  * Abstract Nfc engagement service.
@@ -84,34 +84,6 @@ import org.json.JSONObject
  * @constructor
  */
 abstract class NfcEngagementService : HostApduService() {
-    /**
-     * Override this method if you don't want to send some kind of documents or some kind of keys..
-     * */
-    open fun nfcOnlyFieldAcceptation(
-        jsonString: String
-    ): String {
-        val originalReq = JSONObject(jsonString).optJSONObject("request")
-        val jsonAccepted = JSONObject()
-        originalReq?.keys()?.forEach {
-            originalReq.optJSONObject(it)?.let { json ->
-                val keyJson = JSONObject()
-                json.keys().forEach { key ->
-                    json.optJSONObject(key)?.let { internalJson ->
-                        val internalNewJson = JSONObject()
-                        internalJson.keys().forEach { dataKey ->
-                            internalNewJson.put(dataKey, true)
-                        }
-                        keyJson.put(key, internalNewJson)
-                    }
-                }
-                jsonAccepted.put(it, keyJson)
-            }
-        }
-        return jsonAccepted.toString()
-    }
-
-    private val whatToDoWithRequest: (jsonString: String) -> String
-        get() = { nfcOnlyFieldAcceptation(jsonString = it) }
     private val handler by lazy {
         Handler(Looper.getMainLooper())
     }
@@ -129,6 +101,7 @@ abstract class NfcEngagementService : HostApduService() {
     companion object {
         @SuppressLint("StaticFieldLeak")
         private var nfcEngagement: NfcEngagement? = null
+        private var inactivityTimeout = 15
 
         /**
          * Enable NFC engagement
@@ -157,6 +130,7 @@ abstract class NfcEngagementService : HostApduService() {
             ProximityLogger.i("NfcEngagementService", "disable")
             nfcEngagement?.nfcEngagementHelper?.close()
             nfcEngagement = null
+            NfcEngagementEventBus.resetSetup()
             unsetAsPreferredNfcEngagementService(activity)
         }
 
@@ -284,6 +258,7 @@ abstract class NfcEngagementService : HostApduService() {
 
             override fun onError(error: Throwable) {
                 NfcEngagementEventBus.tryEmit(NfcEngagementEvent.Error(error))
+                nfcEngagement?.close()
             }
 
             override fun onDocumentRequestReceived(
@@ -300,6 +275,7 @@ abstract class NfcEngagementService : HostApduService() {
             }
 
             override fun onDeviceDisconnected(transportSpecificTermination: Boolean) {
+                nfcEngagement?.close()
                 NfcEngagementEventBus.tryEmit(
                     NfcEngagementEvent.Disconnected(
                         transportSpecificTermination
@@ -311,67 +287,71 @@ abstract class NfcEngagementService : HostApduService() {
 
     private fun buildNfcEngagement(retrievalMethods: List<DeviceRetrievalMethod>) {
         if (nfcEngagement == null) {
+            ProximityLogger.i("NfcEngagementService", "Building")
             nfcEngagement = NfcEngagement
                 .build(
                     this@NfcEngagementService.baseContext,
-                    retrievalMethods,
-                    whatToDoWithRequest = whatToDoWithRequest
+                    retrievalMethods
                 ).configure()
             createListeners()
         }
     }
 
-    private val serviceJob = Job()
-    private val serviceScope = CoroutineScope(Dispatchers.Default + serviceJob + SupervisorJob())
+    private val serviceJob = SupervisorJob()
+    private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
 
     @Suppress("UNCHECKED_CAST")
     override fun onCreate() {
         super.onCreate()
+        ProximityLogger.i("NfcEngagementService", "On Create")
         serviceScope.launch {
-            NfcEngagementEventBus.internalEvent.collectLatest { event ->
-                when (event) {
-                    is ServiceEvents.SetupReady -> {
-                        ProximityLogger.i("NfcEngagementService", "SetupReady")
-                        buildNfcEngagement(event.retrievalMethods)
-                        val readerTrustStore = event.readerTrustStore
-                        readerTrustStore?.firstOrNull()?.let { list ->
-                            list.firstOrNull()?.let {
-                                when (it) {
-                                    is Int -> nfcEngagement?.withReaderTrustStore(readerTrustStore as List<List<Int>>)
-                                    is ByteArray -> nfcEngagement?.withReaderTrustStore(
-                                        readerTrustStore as List<List<ByteArray>>
-                                    )
+            NfcEngagementEventBus.setupEvent.filterNotNull().collectLatest { event ->
+                ProximityLogger.i("NfcEngagementService", "SetupReady: $event")
+                buildNfcEngagement(event.retrievalMethods)
+                inactivityTimeout = event.inactivityTimeout
+                val readerTrustStore = event.readerTrustStore
+                readerTrustStore?.firstOrNull()?.let { list ->
+                    list.firstOrNull()?.let {
+                        when (it) {
+                            is Int -> nfcEngagement?.withReaderTrustStore(readerTrustStore as List<List<Int>>)
+                            is ByteArray -> nfcEngagement?.withReaderTrustStore(
+                                readerTrustStore as List<List<ByteArray>>
+                            )
 
-                                    is String -> nfcEngagement?.withReaderTrustStore(
-                                        readerTrustStore as List<List<String>>
-                                    )
+                            is String -> nfcEngagement?.withReaderTrustStore(
+                                readerTrustStore as List<List<String>>
+                            )
 
-                                    else -> throw Exception("readerTrustStore type not supported")
-                                }
-                            } ?: run {
-                                throw Exception("readerTrustStore type not supported")
-                            }
+                            else -> throw Exception("readerTrustStore type not supported")
                         }
-                        event.documents?.let {
-                            nfcEngagement
-                                ?.nfcEngagementHelper
-                                ?.withDocs(event.documents.toTypedArray())
-                        }
-                        event.alias?.let {
-                            nfcEngagement
-                                ?.nfcEngagementHelper
-                                ?.withAlias(event.alias)
-                        }
+                    } ?: run {
+                        throw Exception("readerTrustStore type not supported")
                     }
-
-                    is ServiceEvents.QrCodeDeviceEngagement -> nfcEngagement
-                        ?.nfcEngagementHelper
-                        ?.deviceEngagementFromQr(
-                            event.deviceEngagementSetup.first
-                        )?.setKeyFromQr(
-                            event.deviceEngagementSetup.second
-                        )
                 }
+            }
+        }
+        serviceScope.launch {
+            NfcEngagementEventBus.qrEvent.collectLatest { event ->
+                nfcEngagement
+                    ?.nfcEngagementHelper
+                    ?.deviceEngagementFromQr(
+                        event.deviceEngagementSetup.first
+                    )?.setKeyFromQr(
+                        event.deviceEngagementSetup.second
+                    )
+            }
+        }
+        serviceScope.launch {
+            NfcEngagementEventBus.responseEvent.collectLatest {
+                ProximityLogger.i("NfcEngagementService", "responseEvent")
+                val (back, theEnd) = nfcEngagement?.nfcEngagementHelper?.processDocResponse(
+                    it
+                ) ?: (null to true)
+                sendResponseApdu(
+                    back
+                )
+                if (theEnd)
+                    this@NfcEngagementService.onDeactivated(0)
             }
         }
     }
@@ -385,12 +365,10 @@ abstract class NfcEngagementService : HostApduService() {
     override fun onDeactivated(reason: Int) {
         if (nfcEngagement != null) {
             nfcEngagement?.nfcEngagementHelper?.nfcOnDeactivated(reason)
-            val timeoutSeconds = 15
-            nfcEngagement?.nfcEngagementHelper?.resetAll()
-            Handler(Looper.getMainLooper()).postDelayed({
+            val ble =
+                nfcEngagement?.nfcEngagementHelper?.retrievalMethods?.any { it is BleRetrievalMethod } == true
+            if (!ble)
                 nfcEngagement?.close()
-                nfcEngagement = null
-            }, timeoutSeconds * 1000L)
         }
     }
 
@@ -403,15 +381,16 @@ abstract class NfcEngagementService : HostApduService() {
         serviceScope.launch {
             ProximityLogger.i("NfcEngagementService", "processCommandApdu: ${commandApdu.toHex()}")
             if (nfcEngagement?.nfcEngagementHelper == null) {
-                NfcEngagementEvent.Error(
-                    Throwable("NFC Engagement setup not DONE")
+                NfcEngagementEventBus.tryEmit(
+                    NfcEngagementEvent.Error(
+                        Throwable("NFC Engagement setup not DONE")
+                    )
                 )
                 return@launch
             }
             val (back, theEnd) = nfcEngagement?.nfcEngagementHelper?.nfcProcessCommandApdu(
                 commandApdu
-            )
-                ?: (null to true)
+            ) ?: (null to true)
             ProximityLogger.i("Giving back (theEnd=$theEnd)", back?.toHex().orEmpty())
             back?.let {
                 ProximityLogger.i(
@@ -419,12 +398,16 @@ abstract class NfcEngagementService : HostApduService() {
                     byteArrayOf(back[back.size - 2], back[back.size - 1]).toHex()
                 )
             }
+            val ble =
+                nfcEngagement?.nfcEngagementHelper?.retrievalMethods?.any { it is BleRetrievalMethod } == true
             handler.removeCallbacks(runnable)
             if (theEnd) {
                 this@NfcEngagementService.onDeactivated(0)
             } else {
-                val timeoutSeconds = 3
-                handler.postDelayed(runnable, timeoutSeconds * 1000L)
+                if (!ble) {
+                    val timeoutSeconds = inactivityTimeout.toLong()
+                    handler.postDelayed(runnable, timeoutSeconds * 1000L)
+                }
             }
             sendResponseApdu(back)
         }


### PR DESCRIPTION
## Short description

Now we have an eventBus to manage documents requested in App.

Example:
```kotlin
ResponseGenerator(
                sessionsTranscript = sessionsTranscript
            ).createResponse(
                documents = docRequested.toTypedArray(),
                fieldRequestedAndAccepted = req,
                response = object : ResponseGenerator.Response {
                    override fun onResponseGenerated(response: ByteArray) {
                        ProximityLogger.i(
                            "RESPONSE TO SEND",
                            Base64.encodeToString(response, Base64.NO_WRAP)
                        )
                        if (onlyNfc) {
                            val ok = NfcEngagementEventBus.sendDocumentResponse(response)
                            ProximityLogger.i("RESPONSE SENT", ok.toString())
                            return
                        }
                        this@BaseEngagementViewModel.engagement?.sendResponse(response) ?: run {
                            deviceConnected.sendSessionTermination(response)
                        }
                    }

                    override fun onError(message: String) {
                        this@BaseEngagementViewModel.loader.value = null
                        dialogFailure(message)
                         if (onlyNfc) {
                            val ok =NfcEngagementEventBus.
                                sendDocumentResponse(NfcEngagementService.RESPONSE_GENERATION_ERROR)
                            ProximityLogger.i("RESPONSE SENT", ok.toString())
                            return
                        }
                        val isNoDocFound = message == "no doc found"
                        val toSend = if (isNoDocFound)
                            SessionDataStatus.ERROR_SESSION_ENCRYPTION
                        else
                            SessionDataStatus.ERROR_CBOR_DECODING
                        this@BaseEngagementViewModel.engagement?.sendErrorResponse(toSend) ?: run {
                            deviceConnected.sendErrorResponse(toSend)
                        }
                    }
                }
            )
```
So, as in QR with BLE flow, you can generate your Response with ResponseGenerator and send the event with the response using `NfcEngagementEventBus.sendDocumentResponse`. If an error occurred while generating response you can use `NfcEngagementService.RESPONSE_GENERATION_ERROR` to respond to the verifier app. `onlyNfc` parameter is given back by   `NfcEngagementEvent.DocumentRequestReceived` as in this example:
```kotlin
NfcEngagementEventBus.events.collect { event ->
    if (event is NfcEngagementEvent.DocumentRequestReceived) {
        val request = event.request
        ProximityLogger.i("request", request.toString())
        this@BaseEngagementViewModel.request = request.orEmpty()
        manageRequestFromDeviceUi(event.sessionTranscript, event.onlyNfc)
    }
}
```