### PR TITLE
feat: [SIW-000] add certificate data handling to device request processing

### DIFF
--- a/app/src/main/java/it/pagopa/iso_android/Application.kt
+++ b/app/src/main/java/it/pagopa/iso_android/Application.kt
@@ -13,8 +13,8 @@ class Application : Application() {
             val sslContext: SSLContext = SSLContext.getInstance("TLSv1.2")
             sslContext.init(null, null, null)
             sslContext.createSSLEngine()
-        }catch (e: Exception){
-            ProximityLogger.e("App","Unable to create provider cause: ${e.message}")
+        } catch (e: Exception) {
+            ProximityLogger.e("App", "Unable to create provider cause: ${e.message}")
         }
     }
 }

--- a/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
+++ b/app/src/main/java/it/pagopa/iso_android/ui/view_model/BaseEngagementViewModel.kt
@@ -144,6 +144,8 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
             req.optJSONObject(DocType.MDL.value)?.let { mdlJson ->
                 sb.append("\n${resources.getString(R.string.driving_license)}:\n\n")
                 mdlJson.keys().forEach { key ->
+                    if (key == "certificateData")
+                        return@forEach
                     if (key == "isAuthenticated")
                         ProximityLogger.i("CERT is valid:", "${mdlJson.optBoolean(key)}")
                     mdlJson.optJSONObject(key)?.let { internalJson ->
@@ -157,6 +159,8 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
             req.optJSONObject(DocType.EU_PID.value)?.let { euPidJson ->
                 sb.append("\n${resources.getString(R.string.eu_pid)}:\n\n")
                 euPidJson.keys().forEach { key ->
+                    if (key == "certificateData")
+                        return@forEach
                     if (key == "isAuthenticated")
                         ProximityLogger.i("CERT is valid:", "${euPidJson.optBoolean(key)}")
                     euPidJson.optJSONObject(key)?.let { internalJson ->
@@ -172,6 +176,8 @@ abstract class BaseEngagementViewModel(private val resources: Resources) : BaseV
                 sb.append("\n${it}:\n\n")
                 req.optJSONObject(it)?.let { json ->
                     json.keys().forEach { key ->
+                        if (key == "certificateData")
+                            return@forEach
                         if (key == "isAuthenticated")
                             ProximityLogger.i("CERT is valid:", "${json.optBoolean(key)}")
                         json.optJSONObject(key)?.let { internalJson ->

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/document/ReaderAuth.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/document/ReaderAuth.kt
@@ -13,7 +13,7 @@ import java.security.cert.X509Certificate
  * @property readerCertificateChain reader auth certificate chain as [List] of [X509Certificate]
  * @property readerCertificatedIsTrusted result of reader auth certificate path validation
  * @property readerCommonName the Common Name (CN) field of the reader authentication certificate
- * @property subjectRdnMap the complete map of the reader authentication certificate subject fields.
+ * @property issuerRdnMap the complete map of the reader authentication certificate subject fields.
  * @constructor Create empty Reader auth
  */
 @Parcelize
@@ -24,7 +24,7 @@ class ReaderAuth(
     val readerCertificatedIsTrusted: Boolean,
     val readerCommonName: String,
     val certSerialNumber: BigInteger?,
-    val subjectRdnMap: Map<String, String>
+    val issuerRdnMap: Map<String, String>
 ) : Parcelable {
     /**
      * Whether the reader authentication is success (including that the signature of reader authentication is valid and reader auth

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/document/ReaderAuth.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/document/ReaderAuth.kt
@@ -2,6 +2,7 @@ package it.pagopa.io.wallet.proximity.document
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.math.BigInteger
 import java.security.cert.X509Certificate
 
 /**
@@ -12,6 +13,7 @@ import java.security.cert.X509Certificate
  * @property readerCertificateChain reader auth certificate chain as [List] of [X509Certificate]
  * @property readerCertificatedIsTrusted result of reader auth certificate path validation
  * @property readerCommonName the Common Name (CN) field of the reader authentication certificate
+ * @property subjectRdnMap the complete map of the reader authentication certificate subject fields.
  * @constructor Create empty Reader auth
  */
 @Parcelize
@@ -20,7 +22,9 @@ class ReaderAuth(
     val readerSignIsValid: Boolean,
     val readerCertificateChain: List<X509Certificate>,
     val readerCertificatedIsTrusted: Boolean,
-    val readerCommonName: String
+    val readerCommonName: String,
+    val certSerialNumber: BigInteger?,
+    val subjectRdnMap: Map<String, String>
 ) : Parcelable {
     /**
      * Whether the reader authentication is success (including that the signature of reader authentication is valid and reader auth

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/engagement/Engagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/engagement/Engagement.kt
@@ -59,8 +59,15 @@ abstract class Engagement(val context: Context) {
 
     @JvmName("setReaderTrustStorePrivate")
     private fun <T> List<List<T>>.setReaderTrustStore() {
-        readerTrustStores = this.toReaderTrustStore(context)
+        val readerTrustStores = this.toReaderTrustStore(context)
+        this@Engagement.readerTrustStores = readerTrustStores
+        postReaderTrustStoresSetup(readerTrustStores)
     }
+
+    /**
+     * Override this for cleanup after setting the [readerTrustStores]
+     */
+    protected open fun postReaderTrustStoresSetup(readerTrustStores: List<ReaderTrustStore>) {}
 
     /**
      * Use this if you have certificates into your **Raw Resource** folder.
@@ -129,7 +136,9 @@ abstract class Engagement(val context: Context) {
                     requestWrapperList.add(
                         RequestWrapper(
                             each.itemsRequest,
-                            it?.isSuccess() == true
+                            it?.isSuccess() == true,
+                            it?.certSerialNumber,
+                            it?.subjectRdnMap
                         ).prepare().toJson()
                     )
                 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/engagement/Engagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/engagement/Engagement.kt
@@ -138,7 +138,7 @@ abstract class Engagement(val context: Context) {
                             each.itemsRequest,
                             it?.isSuccess() == true,
                             it?.certSerialNumber,
-                            it?.subjectRdnMap
+                            it?.issuerRdnMap
                         ).prepare().toJson()
                     )
                 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
@@ -19,7 +19,7 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                 jsonToSend
                     .getJSONObject("request")
                     .getJSONObject(docType)
-                    .put("certificateData", it.getJSONObject("issuerRdnMap"))
+                    .put("certificateData", it.optJSONObject("issuerRdnMap"))
             } else {
                 jsonToSend
                     .getJSONObject("request")
@@ -30,7 +30,7 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                 jsonToSend
                     .getJSONObject("request")
                     .getJSONObject(docType)
-                    .put("certificateData", it.getJSONObject("issuerRdnMap"))
+                    .put("certificateData", it.optJSONObject("issuerRdnMap"))
             }
         }
     }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
@@ -19,7 +19,7 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                 jsonToSend
                     .getJSONObject("request")
                     .getJSONObject(docType)
-                    .put("certificateData", it.getJSONObject("subjectRdnMap"))
+                    .put("certificateData", it.getJSONObject("issuerRdnMap"))
             } else {
                 jsonToSend
                     .getJSONObject("request")
@@ -30,7 +30,7 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                 jsonToSend
                     .getJSONObject("request")
                     .getJSONObject(docType)
-                    .put("certificateData", it.getJSONObject("subjectRdnMap"))
+                    .put("certificateData", it.getJSONObject("issuerRdnMap"))
             }
         }
     }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/extensions.kt
@@ -16,6 +16,10 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                     .getJSONObject("request")
                     .getJSONObject(docType)
                     .put("isAuthenticated", it.getBoolean("isAuthenticated"))
+                jsonToSend
+                    .getJSONObject("request")
+                    .getJSONObject(docType)
+                    .put("certificateData", it.getJSONObject("subjectRdnMap"))
             } else {
                 jsonToSend
                     .getJSONObject("request")
@@ -23,6 +27,10 @@ internal fun Array<JSONObject?>.toRequest(): JSONObject {
                 jsonToSend.getJSONObject("request")
                     .getJSONObject(docType)
                     .put("isAuthenticated", it.getBoolean("isAuthenticated"))
+                jsonToSend
+                    .getJSONObject("request")
+                    .getJSONObject(docType)
+                    .put("certificateData", it.getJSONObject("subjectRdnMap"))
             }
         }
     }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagement.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagement.kt
@@ -5,6 +5,7 @@ import com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper
 import com.android.identity.android.mdoc.engagement.NfcEngagementHelper
 import com.android.identity.android.mdoc.transport.DataTransport
 import it.pagopa.io.wallet.proximity.ProximityLogger
+import it.pagopa.io.wallet.proximity.document.reader_auth.ReaderTrustStore
 import it.pagopa.io.wallet.proximity.engagement.Engagement
 import it.pagopa.io.wallet.proximity.retrieval.DeviceRetrievalMethod
 import it.pagopa.io.wallet.proximity.retrieval.connectionMethods
@@ -65,6 +66,10 @@ internal class NfcEngagement(
         override fun onHandoverSelectMessageSent() {
             ProximityLogger.i(this@NfcEngagement.tag, "Handover select message sent")
         }
+    }
+
+    override fun postReaderTrustStoresSetup(readerTrustStores: List<ReaderTrustStore>) {
+        nfcEngagementHelper.readerTrustStores = readerTrustStores
     }
 
     override fun close() {

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
@@ -1036,7 +1036,7 @@ class NfcEngagementHelperRefactor private constructor(
                         each.itemsRequest,
                         it?.isSuccess() == true,
                         it?.certSerialNumber,
-                        it?.subjectRdnMap
+                        it?.issuerRdnMap
                     ).prepare().toJson()
                 )
             }
@@ -1224,7 +1224,6 @@ class NfcEngagementHelperRefactor private constructor(
      * @param context application context.
      * @param eDeviceKey the public part of `EDeviceKey` for *mdoc session
      * encryption* according to ISO/IEC 18013-5:2021 section 9.1.1.4.
-     * @param options set of options for creating [DataTransport] instances.
      * @param listener the listener.
      * @param executor a [Executor] to use with the listener.
      */

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementHelperRefactor.kt
@@ -80,7 +80,7 @@ class NfcEngagementHelperRefactor private constructor(
     private var responseBuffer: ByteArray? = null   // DO'53' already TLV codified
     private var responseOffset: Int = 0
     private var useExtendedLength: Boolean = false
-    private var readerTrustStores: List<ReaderTrustStore>? = listOf()
+    var readerTrustStores: List<ReaderTrustStore>? = listOf()
     private var sessionEncryption: SessionEncryption? = null
     private var deviceEngagementFromQr: ByteArray? = null
 
@@ -1034,7 +1034,9 @@ class NfcEngagementHelperRefactor private constructor(
                 requestWrapperList.add(
                     RequestWrapper(
                         each.itemsRequest,
-                        it?.isSuccess() == true
+                        it?.isSuccess() == true,
+                        it?.certSerialNumber,
+                        it?.subjectRdnMap
                     ).prepare().toJson()
                 )
             }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/CertificateExtensions.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/CertificateExtensions.kt
@@ -90,6 +90,12 @@ internal fun <T> List<List<T>>.toReaderTrustStore(context: Context): List<Reader
 internal infix fun DeviceRequestParserRefactor.DocRequest.toReaderAuthWith(
     readerTrustStores: List<ReaderTrustStore?>?
 ): ReaderAuth? {
+    fun mailOidToMailString(type: String?): String {
+        if (type == null) {
+            return "EMAIL"
+        }
+        return type.uppercase()
+    }
     if (readerTrustStores == null)
         return null
     val trustStore = readerTrustStores.firstOrNull { trustStore ->
@@ -104,12 +110,13 @@ internal infix fun DeviceRequestParserRefactor.DocRequest.toReaderAuthWith(
     val readerAuth = this.readerAuth ?: return null
 
     val cert = certChain.firstOrNull()
-    val subjectPrincipal = cert?.subjectX500Principal
-    val subjectX500Name = X500Name(subjectPrincipal?.name)
+    val subjectPrincipal = cert?.issuerX500Principal
+    val issuerX500Name = X500Name(subjectPrincipal?.name)
 
-    val readerCommonName = IETFUtils.valueToString(subjectX500Name.getRDNs(BCStyle.CN).firstOrNull()?.getFirst()?.value)
-    val subjectRdnMap = subjectX500Name.rdNs.flatMap { it.typesAndValues.toList() }.associate {
-        val label = RFC4519Style.INSTANCE.oidToDisplayName(it.type).uppercase()
+    val readerCommonName =
+        IETFUtils.valueToString(issuerX500Name.getRDNs(BCStyle.CN).firstOrNull()?.getFirst()?.value)
+    val issuerRdnMap = issuerX500Name.rdNs.flatMap { it.typesAndValues.toList() }.associate {
+        val label = mailOidToMailString(RFC4519Style.INSTANCE.oidToDisplayName(it.type))
         val value = it.value.toString()
         label to value
     }
@@ -118,9 +125,10 @@ internal infix fun DeviceRequestParserRefactor.DocRequest.toReaderAuthWith(
         readerAuth,
         this.readerAuthenticated,
         readerCertificateChain.javaX509Certificates,
-        trustStore?.validateCertificationTrustPath(readerCertificateChain.javaX509Certificates) ?: false,
+        trustStore?.validateCertificationTrustPath(readerCertificateChain.javaX509Certificates)
+            ?: false,
         readerCommonName,
         cert?.serialNumber,
-        subjectRdnMap
+        issuerRdnMap
     )
 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/CertificateExtensions.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/qr_code/CertificateExtensions.kt
@@ -8,11 +8,16 @@ import it.pagopa.io.wallet.proximity.ProximityLogger
 import it.pagopa.io.wallet.proximity.document.ReaderAuth
 import it.pagopa.io.wallet.proximity.document.reader_auth.ReaderTrustStore
 import it.pagopa.io.wallet.proximity.parser.DeviceRequestParserRefactor
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x500.style.BCStyle
+import org.bouncycastle.asn1.x500.style.IETFUtils
+import org.bouncycastle.asn1.x500.style.RFC4519Style
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.Base64
+
 
 private fun InputStream.toX509Certificate(): X509Certificate? {
     return CertificateFactory.getInstance("X.509").generateCertificate(this) as? X509Certificate
@@ -93,26 +98,29 @@ internal infix fun DeviceRequestParserRefactor.DocRequest.toReaderAuthWith(
         trustStore?.validateCertificationTrustPath(readerCertificateChain.javaX509Certificates) == true
     }
     val readerCertificateChain = this.readerCertificateChain ?: return null
-    if (trustStore == null)
-        return null
     val certChain =
-        trustStore.createCertificationTrustPath(readerCertificateChain.javaX509Certificates)
+        trustStore?.createCertificationTrustPath(readerCertificateChain.javaX509Certificates)
             ?.takeIf { it.isNotEmpty() } ?: readerCertificateChain.javaX509Certificates
     val readerAuth = this.readerAuth ?: return null
-    val readerCommonName = certChain.firstOrNull()
-        ?.subjectX500Principal
-        ?.name
-        ?.split(",")
-        ?.map { it.split("=", limit = 2) }
-        ?.firstOrNull { it.size == 2 && it[0] == "CN" }
-        ?.get(1)
-        ?.trim()
-        ?: ""
+
+    val cert = certChain.firstOrNull()
+    val subjectPrincipal = cert?.subjectX500Principal
+    val subjectX500Name = X500Name(subjectPrincipal?.name)
+
+    val readerCommonName = IETFUtils.valueToString(subjectX500Name.getRDNs(BCStyle.CN).firstOrNull()?.getFirst()?.value)
+    val subjectRdnMap = subjectX500Name.rdNs.flatMap { it.typesAndValues.toList() }.associate {
+        val label = RFC4519Style.INSTANCE.oidToDisplayName(it.type).uppercase()
+        val value = it.value.toString()
+        label to value
+    }
+
     return ReaderAuth(
         readerAuth,
         this.readerAuthenticated,
         readerCertificateChain.javaX509Certificates,
-        trustStore.validateCertificationTrustPath(readerCertificateChain.javaX509Certificates),
-        readerCommonName
+        trustStore?.validateCertificationTrustPath(readerCertificateChain.javaX509Certificates) ?: false,
+        readerCommonName,
+        cert?.serialNumber,
+        subjectRdnMap
     )
 }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/request/RequestWrapper.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/request/RequestWrapper.kt
@@ -9,11 +9,14 @@ import it.pagopa.io.wallet.cbor.parser.CBorParser
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
+import java.math.BigInteger
 
 @Parcelize
 internal data class RequestWrapper(
     private val cborByte: ByteArray,
-    val isAuthenticated: Boolean = false
+    val isAuthenticated: Boolean = false,
+    val certSerialNumber: BigInteger?,
+    val subjectRdnMap: Map<String, String>?,
 ) : Parcelable {
     @IgnoredOnParcel
     var requiredFields: CBORObject? = null
@@ -34,6 +37,12 @@ internal data class RequestWrapper(
                 put("docType", docTypeCbor)
                 put("values", JSONObject(it))
                 put("isAuthenticated", isAuthenticated)
+                certSerialNumber?.let { serial ->
+                    put("certificateSerial", serial.toString())
+                }
+                subjectRdnMap?.let { map ->
+                    put("subjectRdnMap", JSONObject(map))
+                }
             }
         }
     }

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/request/RequestWrapper.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/request/RequestWrapper.kt
@@ -4,7 +4,6 @@ package it.pagopa.io.wallet.proximity.request
 
 import android.os.Parcelable
 import com.upokecenter.cbor.CBORObject
-import it.pagopa.io.wallet.cbor.model.DocType
 import it.pagopa.io.wallet.cbor.parser.CBorParser
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -16,7 +15,7 @@ internal data class RequestWrapper(
     private val cborByte: ByteArray,
     val isAuthenticated: Boolean = false,
     val certSerialNumber: BigInteger?,
-    val subjectRdnMap: Map<String, String>?,
+    val issuerRdnMap: Map<String, String>?,
 ) : Parcelable {
     @IgnoredOnParcel
     var requiredFields: CBORObject? = null
@@ -40,8 +39,8 @@ internal data class RequestWrapper(
                 certSerialNumber?.let { serial ->
                     put("certificateSerial", serial.toString())
                 }
-                subjectRdnMap?.let { map ->
-                    put("subjectRdnMap", JSONObject(map))
+                issuerRdnMap?.let { map ->
+                    put("issuerRdnMap", JSONObject(map))
                 }
             }
         }

--- a/proximity/src/test/java/it/pagopa/io/wallet/proximity/RequestWrapperTest.kt
+++ b/proximity/src/test/java/it/pagopa/io/wallet/proximity/RequestWrapperTest.kt
@@ -4,6 +4,7 @@ import it.pagopa.io.wallet.cbor.model.DocType
 import it.pagopa.io.wallet.proximity.request.RequestWrapper
 import org.json.JSONObject
 import org.junit.Test
+import java.math.BigInteger
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -19,8 +20,8 @@ class RequestWrapperTest {
     @Test
     fun `test request from device JSON`() {
         val requestWrapperList = arrayListOf<JSONObject?>()
-        val req = RequestWrapper(Base64.decode(mockEuPidRequest), false).prepare().toJson()
-        val req1 = RequestWrapper(Base64.decode(mockMdlRequest), false).prepare().toJson()
+        val req = RequestWrapper(Base64.decode(mockEuPidRequest), false, BigInteger("1111"), null).prepare().toJson()
+        val req1 = RequestWrapper(Base64.decode(mockMdlRequest), false, BigInteger("2222"), null).prepare().toJson()
         requestWrapperList.addAll(listOf(req, req1))
         val jsonToSend = requestWrapperList.toTypedArray().toRequest()
         println(jsonToSend)

--- a/proximity/src/test/java/it/pagopa/io/wallet/proximity/RequestWrapperTest.kt
+++ b/proximity/src/test/java/it/pagopa/io/wallet/proximity/RequestWrapperTest.kt
@@ -20,8 +20,8 @@ class RequestWrapperTest {
     @Test
     fun `test request from device JSON`() {
         val requestWrapperList = arrayListOf<JSONObject?>()
-        val req = RequestWrapper(Base64.decode(mockEuPidRequest), false, BigInteger("1111"), null).prepare().toJson()
-        val req1 = RequestWrapper(Base64.decode(mockMdlRequest), false, BigInteger("2222"), null).prepare().toJson()
+        val req = RequestWrapper(Base64.decode(mockEuPidRequest), false, BigInteger("1111"), mapOf("C" to "UT","O" to "EUDI Wallet Reference Implementation","SERIALNUMBER" to "001","CN" to "EUDI Proximity Verifier")).prepare().toJson()
+        val req1 = RequestWrapper(Base64.decode(mockMdlRequest), false, BigInteger("2222"), mapOf("C" to "UT","O" to "EUDI Wallet Reference Implementation","SERIALNUMBER" to "001","CN" to "EUDI Proximity Verifier")).prepare().toJson()
         requestWrapperList.addAll(listOf(req, req1))
         val jsonToSend = requestWrapperList.toTypedArray().toRequest()
         println(jsonToSend)


### PR DESCRIPTION
# Short description

Add certificate data handling to device request processing

## Example response:

```json
{
  "request": {
    "eu.europa.ec.eudi.pid.1": {
      "eu.europa.ec.eudi.pid.1": {
        "gender": false,
        "portrait": false,
        "birth_city": false,
        "birth_date": false,
        "given_name": false,
        "age_over_13": false,
        "age_over_16": false,
        "age_over_18": false,
        "age_over_21": false,
        "age_over_60": false,
        "age_over_65": false,
        "age_over_68": false,
        "birth_place": false,
        "birth_state": false,
        "expiry_date": false,
        "family_name": false,
        "nationality": false,
        "age_in_years": false,
        "birth_country": false,
        "issuance_date": false,
        "resident_city": false,
        "age_birth_year": false,
        "resident_state": false,
        "document_number": false,
        "issuing_country": false,
        "resident_street": false,
        "given_name_birth": false,
        "resident_address": false,
        "resident_country": false,
        "family_name_birth": false,
        "issuing_authority": false,
        "issuing_jurisdiction": false,
        "resident_postal_code": false,
        "administrative_number": false,
        "portrait_capture_date": false,
        "resident_house_number": false
      },
      "isAuthenticated": false,
      "certificateData": {
        "C": "UT",
        "O": "EUDI Wallet Reference Implementation",
        "SERIALNUMBER": "001",
        "CN": "EUDI Proximity Verifier"
      }
    }
  }
}
```
