### PR TITLE
feat: [SIW-001] solved background service starting without open app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <service
             android:name=".nfc.AppNfcEngagementService"
             android:exported="true"
+            android:enabled="false"
             android:label="@string/nfc_engagement_service_desc"
             android:permission="android.permission.BIND_NFC_SERVICE">
             <intent-filter>

--- a/app/src/main/java/it/pagopa/iso_android/MainActivity.kt
+++ b/app/src/main/java/it/pagopa/iso_android/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.compose.rememberNavController
 import it.pagopa.io.wallet.cbor.CborLogger
 import it.pagopa.io.wallet.proximity.ProximityLogger
+import it.pagopa.io.wallet.proximity.nfc.NfcEngagementService
 import it.pagopa.iso_android.navigation.IsoAndroidPocNavHost
 import it.pagopa.iso_android.navigation.menu.DrawerBody
 import it.pagopa.iso_android.navigation.menu.TopBar
@@ -37,12 +38,18 @@ import it.pagopa.iso_android.ui.theme.IsoAndroidPocTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        NfcEngagementService.disable(this)
         enableEdgeToEdge()
         ProximityLogger.enabled = BuildConfig.DEBUG
         CborLogger.enabled = BuildConfig.DEBUG
         setContent {
             this.MainApp()
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        NfcEngagementService.disable(this)
     }
 }
 

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
@@ -103,6 +103,7 @@ abstract class NfcEngagementService : HostApduService() {
         @SuppressLint("StaticFieldLeak")
         private var nfcEngagement: NfcEngagement? = null
         private var inactivityTimeout = 15
+        private var serviceClass: Class<out NfcEngagementService>? = null
 
         val RESPONSE_GENERATION_ERROR = NfcUtil.STATUS_WORD_FILE_NOT_FOUND
 
@@ -117,6 +118,15 @@ abstract class NfcEngagementService : HostApduService() {
             activity: Activity,
             preferredNfcEngSerCls: Class<out NfcEngagementService>? = null,
         ): HceServiceStatus {
+            serviceClass = preferredNfcEngSerCls
+            // Enable the service component programmatically
+            preferredNfcEngSerCls?.let {
+                activity.packageManager.setComponentEnabledSetting(
+                    ComponentName(activity, it),
+                    android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    android.content.pm.PackageManager.DONT_KILL_APP
+                )
+            }
             // set preferred Nfc Engagement Service
             return preferredNfcEngSerCls?.let {
                 setAsPreferredNfcEngagementService(activity, it)
@@ -135,6 +145,15 @@ abstract class NfcEngagementService : HostApduService() {
             nfcEngagement = null
             NfcEngagementEventBus.resetSetup()
             unsetAsPreferredNfcEngagementService(activity)
+            // Disable the service component programmatically
+            serviceClass?.let {
+                activity.packageManager.setComponentEnabledSetting(
+                    ComponentName(activity, it),
+                    android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    android.content.pm.PackageManager.DONT_KILL_APP
+                )
+            }
+            serviceClass = null
         }
 
         private fun Int.cardEmulationClearLog() = when (this) {


### PR DESCRIPTION
## Short description

Now nfc service is working just when app is opened.

## List of changes proposed in this pull request

into AndroidManifest:
```xml
<service
            android:name=".nfc.AppNfcEngagementService"
            android:exported="true"
            android:enabled="false"<!--This is really important!!-->
            android:label="@string/nfc_engagement_service_desc"
            android:permission="android.permission.BIND_NFC_SERVICE">
            <intent-filter>
                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
                <category android:name="android.intent.category.DEFAULT"/>
            </intent-filter>

            <meta-data
                android:name="android.nfc.cardemulation.host_apdu_service"
                android:resource="@xml/nfc_engagement_apdu_service" />
        </service>
```

Into your activity Lifecycle:

OnCreate and onPause Event:
```kotlin
NfcEngagementService.disable(activity)
```
