### PR TITLE
fix(nfc): [SIW-000] cancel inactivity timeout on session end

### DIFF
--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
@@ -308,6 +308,7 @@ abstract class NfcEngagementService : HostApduService() {
 
     private fun cancelInactivityTimeout() {
         handler.removeCallbacks(runnable)
+        ProximityLogger.i("NfcEngagementService", "Inactivity timeout canceled")
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -416,13 +417,15 @@ abstract class NfcEngagementService : HostApduService() {
             }
             val ble =
                 nfcEngagement?.nfcEngagementHelper?.retrievalMethods?.any { it is BleRetrievalMethod } == true
-            handler.removeCallbacks(runnable)
+            cancelInactivityTimeout()
+
             if (theEnd) {
                 this@NfcEngagementService.onDeactivated(0)
             } else {
                 if (!ble) {
                     val timeoutSeconds = inactivityTimeout.toLong()
                     handler.postDelayed(runnable, timeoutSeconds * 1000L)
+                    ProximityLogger.i("NfcEngagementService", "Inactivity timeout registered")
                 }
             }
             sendResponseApdu(back)

--- a/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
+++ b/proximity/src/main/java/it/pagopa/io/wallet/proximity/nfc/NfcEngagementService.kt
@@ -102,6 +102,8 @@ abstract class NfcEngagementService : HostApduService() {
     companion object {
         @SuppressLint("StaticFieldLeak")
         private var nfcEngagement: NfcEngagement? = null
+        @SuppressLint("StaticFieldLeak")
+        private var activeService: NfcEngagementService? = null
         private var inactivityTimeout = 15
 
         val RESPONSE_GENERATION_ERROR = NfcUtil.STATUS_WORD_FILE_NOT_FOUND
@@ -131,6 +133,7 @@ abstract class NfcEngagementService : HostApduService() {
         @JvmStatic
         fun disable(activity: Activity) {
             ProximityLogger.i("NfcEngagementService", "disable")
+            activeService?.cancelInactivityTimeout()
             nfcEngagement?.nfcEngagementHelper?.close()
             nfcEngagement = null
             NfcEngagementEventBus.resetSetup()
@@ -303,9 +306,14 @@ abstract class NfcEngagementService : HostApduService() {
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
 
+    private fun cancelInactivityTimeout() {
+        handler.removeCallbacks(runnable)
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun onCreate() {
         super.onCreate()
+        activeService = this
         ProximityLogger.i("NfcEngagementService", "On Create")
         serviceScope.launch {
             NfcEngagementEventBus.setupEvent.filterNotNull().collectLatest { event ->
@@ -362,10 +370,15 @@ abstract class NfcEngagementService : HostApduService() {
     override fun onDestroy() {
         super.onDestroy()
         ProximityLogger.i("NfcEngagementService", "On Destroy")
+        cancelInactivityTimeout()
+        if (activeService === this) {
+            activeService = null
+        }
         serviceJob.cancel()
     }
 
     override fun onDeactivated(reason: Int) {
+        cancelInactivityTimeout()
         if (nfcEngagement != null) {
             nfcEngagement?.nfcEngagementHelper?.nfcOnDeactivated(reason)
             val ble =


### PR DESCRIPTION
## Short description

Fix an NFC session restart issue where a stale inactivity timeout from a previous session could close a newly started session.

## List of changes proposed in this pull request

- Track the active NFC engagement service instance
- Cancel pending inactivity timeout callbacks when the NFC session is disabled, deactivated, or destroyed

## How to test

- Run `./gradlew :proximity:compileDebugKotlin`
- Start an NFC proximity flow
- Trigger the verifier consent path
- Approve consent and restart the flow
- Verify the restarted NFC session does not timeout after a few seconds